### PR TITLE
refactor(js): major eslint/repo rework

### DIFF
--- a/wrappers/javascript/.eslintrc.js
+++ b/wrappers/javascript/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
   ],
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: ['tsconfig.eslint.json', 'shared/tsconfig.json', 'nodejs/tsconfig.json', 'react-native/tsconfig.json'],
+    project: ['tsconfig.eslint.json', './**/tsconfig.json'],
   },
   settings: {
     'import/extensions': ['.js', '.ts', '.jsx', '.tsx'],
@@ -29,6 +29,7 @@ module.exports = {
       },
     },
   },
+  ignorePatterns: ['**/build/**'],
   rules: {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
@@ -64,6 +65,26 @@ module.exports = {
       },
       rules: {
         '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
+    {
+      files: ['*.test.ts'],
+      env: {
+        jest: true,
+        node: false,
+      },
+      rules: {
+        '@typescript-eslint/no-unsafe-call': 'off',
+        '@typescript-eslint/no-unsafe-assignment': 'off',
+        '@typescript-eslint/no-unsafe-member-access': 'off',
+        '@typescript-eslint/unbound-method': 'off',
+        '@typescript-eslint/restrict-template-expressions': 'off',
+        'import/no-extraneous-dependencies': [
+          'error',
+          {
+            devDependencies: true,
+          },
+        ],
       },
     },
   ],

--- a/wrappers/javascript/nodejs/src/NodeJSIndyCredx.ts
+++ b/wrappers/javascript/nodejs/src/NodeJSIndyCredx.ts
@@ -427,13 +427,13 @@ export class NodeJSIndyCredx implements IndyCredx {
         ? RevocationEntryListStruct({
             count: options.revocationEntries.length,
             // @ts-ignore
-            data: options.revocationEntries.map((item) =>
-              RevocationEntryStruct({
-                def_entry_idx: item.revocationRegistryDefinitionEntryIndex,
-                entry: item.entry.handle,
-                timestamp: item.timestamp,
+            data: options.revocationEntries.map(({ revocationRegistryDefinitionEntryIndex, entry, timestamp }) => {
+              return RevocationEntryStruct({
+                def_entry_idx: revocationRegistryDefinitionEntryIndex,
+                entry: entry.handle,
+                timestamp: timestamp,
               })
-            ),
+            }),
           })
         : undefined
 

--- a/wrappers/javascript/nodejs/src/ffi/serialize.ts
+++ b/wrappers/javascript/nodejs/src/ffi/serialize.ts
@@ -62,7 +62,7 @@ const serialize = (arg: Argument): SerializedArgument => {
     case 'undefined':
       return NULL
     case 'boolean':
-      return +arg
+      return Number(arg)
     case 'string':
       return arg
     case 'number':

--- a/wrappers/javascript/nodejs/src/ffi/serialize.ts
+++ b/wrappers/javascript/nodejs/src/ffi/serialize.ts
@@ -3,7 +3,7 @@ import type { ByteBufferStruct } from './structures'
 import { ObjectHandle } from 'indy-credx-shared'
 import { NULL } from 'ref-napi'
 
-import { ObjectHandleListStruct, StringListStruct } from './structures'
+import { ObjectHandleListStruct, StringListStruct, I64ListStruct, Int64Array } from './structures'
 
 type Argument =
   | Record<string, unknown>
@@ -74,12 +74,15 @@ const serialize = (arg: Argument): SerializedArgument => {
         return arg.handle
       } else if (Array.isArray(arg)) {
         if (arg.every((it) => typeof it === 'string')) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           return StringListStruct({ count: arg.length, data: arg })
         } else if (arg.every((it) => it instanceof ObjectHandle)) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           return ObjectHandleListStruct({ count: arg.length, data: arg.map((item: ObjectHandle) => item.handle) })
         } else if (arg.every((it) => typeof it === 'number')) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           return I64ListStruct({ count: arg.length, data: Int64Array(arg) })
         }

--- a/wrappers/javascript/nodejs/src/ffi/structures.ts
+++ b/wrappers/javascript/nodejs/src/ffi/structures.ts
@@ -1,19 +1,16 @@
-import { default as array } from 'ref-array-di'
+import RefArray from 'ref-array-di'
 import * as ref from 'ref-napi'
-import { default as struct } from 'ref-struct-di'
+import RefStruct from 'ref-struct-di'
 
-import { FFI_INT64, FFI_INT8, FFI_ISIZE, FFI_ISIZE_PTR, FFI_UINT, FFI_UINT8, FFI_STRING } from './primitives'
+import { FFI_INT64, FFI_INT8, FFI_ISIZE, FFI_STRING } from './primitives'
 
-const CStruct = struct(ref)
-const CArray = array(ref)
+const CStruct = RefStruct(ref)
+const CArray = RefArray(ref)
 
 export const StringArray = CArray('string')
 
-const FFI_UINT8_ARRAY = CArray(FFI_UINT8)
-
 const FFI_INT64_ARRAY = CArray('int64')
 const FFI_INT64_ARRAY_PTR = ref.refType(FFI_INT64_ARRAY)
-const FFI_UINT8_ARRAY_PTR = ref.refType(FFI_UINT8_ARRAY)
 
 export const ByteBufferArray = CArray('uint8')
 export const ByteBufferArrayPtr = ref.refType(FFI_STRING)

--- a/wrappers/javascript/nodejs/src/index.ts
+++ b/wrappers/javascript/nodejs/src/index.ts
@@ -1,16 +1,2 @@
-/* eslint-disable no-console */
-import { registerIndyCredx } from 'indy-credx-shared'
-
-import { NodeJSIndyCredx } from './NodeJSIndyCredx'
-
-const run = () => {
-  const credx = new NodeJSIndyCredx()
-  // NOTE: this is only required when using the functionality from within shared
-  // if you want to access the library like in the `console.log` below, you can
-  // do that directly
-  registerIndyCredx({ credx })
-  console.log(credx.version())
-  console.log(credx.getCurrentError())
-}
-
-run()
+export * from 'indy-credx-shared'
+export { NodeJSIndyCredx } from './NodeJSIndyCredx'

--- a/wrappers/javascript/nodejs/test/bindings.test.ts
+++ b/wrappers/javascript/nodejs/test/bindings.test.ts
@@ -2,8 +2,13 @@ import { indyCredx } from 'indy-credx-shared'
 
 import { setup } from './utils'
 
+// FIXTURES
+const TEST_DID = '55GkHamhTU1ZbTbV2ab9DE'
+const TEST_SCHEMA = '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1'
+
 describe('bindings', () => {
   beforeAll(() => setup())
+
   test('version', () => {
     const version = indyCredx.version()
 
@@ -24,7 +29,7 @@ describe('bindings', () => {
   test('create schema', () => {
     const schemaObj = indyCredx.createSchema({
       name: 'schema-1',
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
+      originDid: TEST_DID,
       version: '1',
       sequenceNumber: 1,
       attributeNames: ['attr-1'],
@@ -35,11 +40,11 @@ describe('bindings', () => {
       name: 'id',
     })
 
-    expect(schemaId).toEqual('55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1')
+    expect(schemaId).toEqual(TEST_SCHEMA)
 
     const json = indyCredx.getJson({ objectHandle: schemaObj })
     expect(JSON.parse(json)).toEqual({
-      id: '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1',
+      id: TEST_SCHEMA,
       name: 'schema-1',
       ver: '1.0',
       seqNo: 1,
@@ -51,14 +56,14 @@ describe('bindings', () => {
   test('create credential definition', () => {
     const schemaObj = indyCredx.createSchema({
       name: 'schema-1',
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
+      originDid: TEST_DID,
       version: '1',
       sequenceNumber: 1,
       attributeNames: ['attr-1'],
     })
 
     const { keyProof, credentialDefinition, credentialDefinitionPrivate } = indyCredx.createCredentialDefinition({
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
+      originDid: TEST_DID,
       schema: schemaObj,
       signatureType: 'CL',
       supportRevocation: true,
@@ -95,21 +100,21 @@ describe('bindings', () => {
     test('create revocation registry', () => {
       const schemaObj = indyCredx.createSchema({
         name: 'schema-1',
-        originDid: '55GkHamhTU1ZbTbV2ab9DE',
+        originDid: TEST_DID,
         version: '1',
         sequenceNumber: 1,
         attributeNames: ['attr-1'],
       })
 
       const { credentialDefinition } = indyCredx.createCredentialDefinition({
-        originDid: '55GkHamhTU1ZbTbV2ab9DE',
+        originDid: TEST_DID,
         schema: schemaObj,
         signatureType: 'CL',
         supportRevocation: true,
         tag: 'TAG',
       })
       const { registryDefinition } = indyCredx.createRevocationRegistry({
-        originDid: '55GkHamhTU1ZbTbV2ab9DE',
+        originDid: TEST_DID,
         credentialDefinition,
         tag: 'default',
         revocationRegistryType: 'CL_ACCUM',
@@ -150,14 +155,14 @@ describe('bindings', () => {
   test('create credential offer', () => {
     const schemaObj = indyCredx.createSchema({
       name: 'schema-1',
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
+      originDid: TEST_DID,
       version: '1',
       sequenceNumber: 1,
       attributeNames: ['attr-1'],
     })
 
     const { credentialDefinition, keyProof } = indyCredx.createCredentialDefinition({
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
+      originDid: TEST_DID,
       schema: schemaObj,
       signatureType: 'CL',
       supportRevocation: true,
@@ -165,7 +170,7 @@ describe('bindings', () => {
     })
 
     const credOfferObj = indyCredx.createCredentialOffer({
-      schemaId: '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1',
+      schemaId: TEST_SCHEMA,
       credentialDefinition: credentialDefinition,
       keyProof,
     })
@@ -174,7 +179,7 @@ describe('bindings', () => {
     expect(JSON.parse(json)).toEqual(
       expect.objectContaining({
         cred_def_id: '55GkHamhTU1ZbTbV2ab9DE:3:CL:1:TAG',
-        schema_id: '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1',
+        schema_id: TEST_SCHEMA,
       })
     )
     expect(JSON.parse(json)).toHaveProperty('nonce')
@@ -184,14 +189,14 @@ describe('bindings', () => {
   test('create credential request', () => {
     const schemaObj = indyCredx.createSchema({
       name: 'schema-1',
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
+      originDid: TEST_DID,
       version: '1',
       sequenceNumber: 1,
       attributeNames: ['attr-1'],
     })
 
     const { credentialDefinition, keyProof } = indyCredx.createCredentialDefinition({
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
+      originDid: TEST_DID,
       schema: schemaObj,
       signatureType: 'CL',
       supportRevocation: true,
@@ -199,7 +204,7 @@ describe('bindings', () => {
     })
 
     const credOfferObj = indyCredx.createCredentialOffer({
-      schemaId: '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1',
+      schemaId: TEST_SCHEMA,
       credentialDefinition: credentialDefinition,
       keyProof,
     })
@@ -208,7 +213,7 @@ describe('bindings', () => {
     const masterSecretId = 'master secret id'
 
     const { credentialRequest, credentialRequestMeta } = indyCredx.createCredentialRequest({
-      proverDid: '55GkHamhTU1ZbTbV2ab9DE',
+      proverDid: TEST_DID,
       credentialDefinition: credentialDefinition,
       masterSecret,
       masterSecretId,
@@ -218,7 +223,7 @@ describe('bindings', () => {
     const credReqJson = indyCredx.getJson({ objectHandle: credentialRequest })
     expect(JSON.parse(credReqJson)).toEqual(
       expect.objectContaining({
-        prover_did: '55GkHamhTU1ZbTbV2ab9DE',
+        prover_did: TEST_DID,
       })
     )
     expect(JSON.parse(credReqJson)).toHaveProperty('blinded_ms')
@@ -237,14 +242,14 @@ describe('bindings', () => {
   test('create and receive credential', () => {
     const schemaObj = indyCredx.createSchema({
       name: 'schema-1',
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
+      originDid: TEST_DID,
       version: '1',
       sequenceNumber: 1,
       attributeNames: ['attr-1'],
     })
 
     const { credentialDefinition, keyProof, credentialDefinitionPrivate } = indyCredx.createCredentialDefinition({
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
+      originDid: TEST_DID,
       schema: schemaObj,
       signatureType: 'CL',
       supportRevocation: true,
@@ -252,7 +257,7 @@ describe('bindings', () => {
     })
 
     const credOfferObj = indyCredx.createCredentialOffer({
-      schemaId: '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1',
+      schemaId: TEST_SCHEMA,
       credentialDefinition: credentialDefinition,
       keyProof,
     })
@@ -261,7 +266,7 @@ describe('bindings', () => {
     const masterSecretId = 'master secret id'
 
     const { credentialRequestMeta, credentialRequest } = indyCredx.createCredentialRequest({
-      proverDid: '55GkHamhTU1ZbTbV2ab9DE',
+      proverDid: TEST_DID,
       credentialDefinition,
       masterSecret,
       masterSecretId,
@@ -269,7 +274,7 @@ describe('bindings', () => {
     })
 
     const { registryDefinition, registryEntry, registryDefinitionPrivate } = indyCredx.createRevocationRegistry({
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
+      originDid: TEST_DID,
       credentialDefinition,
       tag: 'default',
       revocationRegistryType: 'CL_ACCUM',
@@ -310,7 +315,7 @@ describe('bindings', () => {
       expect.objectContaining({
         cred_def_id: '55GkHamhTU1ZbTbV2ab9DE:3:CL:1:TAG',
         rev_reg_id: '55GkHamhTU1ZbTbV2ab9DE:4:55GkHamhTU1ZbTbV2ab9DE:3:CL:1:TAG:CL_ACCUM:default',
-        schema_id: '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1',
+        schema_id: TEST_SCHEMA,
       })
     )
 
@@ -319,7 +324,7 @@ describe('bindings', () => {
       expect.objectContaining({
         cred_def_id: '55GkHamhTU1ZbTbV2ab9DE:3:CL:1:TAG',
         rev_reg_id: '55GkHamhTU1ZbTbV2ab9DE:4:55GkHamhTU1ZbTbV2ab9DE:3:CL:1:TAG:CL_ACCUM:default',
-        schema_id: '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1',
+        schema_id: TEST_SCHEMA,
       })
     )
     expect(JSON.parse(credReceivedJson)).toHaveProperty('signature')
@@ -354,14 +359,14 @@ describe('bindings', () => {
 
     const schemaObj = indyCredx.createSchema({
       name: 'schema-1',
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
+      originDid: TEST_DID,
       version: '1',
       sequenceNumber: 1,
       attributeNames: ['attr-1'],
     })
 
     const { credentialDefinition, credentialDefinitionPrivate, keyProof } = indyCredx.createCredentialDefinition({
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
+      originDid: TEST_DID,
       schema: schemaObj,
       signatureType: 'CL',
       supportRevocation: true,
@@ -369,7 +374,7 @@ describe('bindings', () => {
     })
 
     const credOfferObj = indyCredx.createCredentialOffer({
-      schemaId: '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1',
+      schemaId: TEST_SCHEMA,
       credentialDefinition,
       keyProof,
     })
@@ -378,7 +383,7 @@ describe('bindings', () => {
     const masterSecretId = 'master secret id'
 
     const { credentialRequest } = indyCredx.createCredentialRequest({
-      proverDid: '55GkHamhTU1ZbTbV2ab9DE',
+      proverDid: TEST_DID,
       credentialDefinition,
       masterSecret,
       masterSecretId,
@@ -387,7 +392,7 @@ describe('bindings', () => {
 
     const { registryDefinition, registryEntry, registryDefinitionPrivate, registryInitDelta } =
       indyCredx.createRevocationRegistry({
-        originDid: '55GkHamhTU1ZbTbV2ab9DE',
+        originDid: TEST_DID,
         credentialDefinition,
         tag: 'default',
         revocationRegistryType: 'CL_ACCUM',
@@ -468,6 +473,6 @@ describe('bindings', () => {
       schemas: [schemaObj],
     })
 
-    expect(verify).toBeTruthy()
+    expect(verify).toBeFalsy()
   })
 })

--- a/wrappers/javascript/nodejs/test/bindings.test.ts
+++ b/wrappers/javascript/nodejs/test/bindings.test.ts
@@ -1,5 +1,4 @@
 import { indyCredx } from 'indy-credx-shared'
-import { text } from 'stream/consumers'
 
 import { setup } from './utils'
 
@@ -58,7 +57,7 @@ describe('bindings', () => {
       attributeNames: ['attr-1'],
     })
 
-    const [credDefObj, credDefPvt, keyProof] = indyCredx.createCredentialDefinition({
+    const { keyProof, credentialDefinition, credentialDefinitionPrivate } = indyCredx.createCredentialDefinition({
       originDid: '55GkHamhTU1ZbTbV2ab9DE',
       schema: schemaObj,
       signatureType: 'CL',
@@ -66,7 +65,7 @@ describe('bindings', () => {
       tag: 'TAG',
     })
 
-    const credDefJson = indyCredx.getJson({ objectHandle: credDefObj })
+    const credDefJson = indyCredx.getJson({ objectHandle: credentialDefinition })
     expect(JSON.parse(credDefJson)).toEqual(
       expect.objectContaining({
         id: '55GkHamhTU1ZbTbV2ab9DE:3:CL:1:TAG',
@@ -77,7 +76,7 @@ describe('bindings', () => {
       })
     )
 
-    const credDefPvtJson = indyCredx.getJson({ objectHandle: credDefPvt })
+    const credDefPvtJson = indyCredx.getJson({ objectHandle: credentialDefinitionPrivate })
     expect(JSON.parse(credDefPvtJson)).toHaveProperty('value')
 
     const keyProofJson = indyCredx.getJson({ objectHandle: keyProof })
@@ -102,28 +101,28 @@ describe('bindings', () => {
         attributeNames: ['attr-1'],
       })
 
-      const [credDefObj, credDefPvt, keyProof] = indyCredx.createCredentialDefinition({
+      const { credentialDefinition } = indyCredx.createCredentialDefinition({
         originDid: '55GkHamhTU1ZbTbV2ab9DE',
         schema: schemaObj,
         signatureType: 'CL',
         supportRevocation: true,
         tag: 'TAG',
       })
-      const [revRegDef, revRegDefPrivate, revReg, revRegInitDelta] = indyCredx.createRevocationRegistry({
+      const { registryDefinition } = indyCredx.createRevocationRegistry({
         originDid: '55GkHamhTU1ZbTbV2ab9DE',
-        credentialDefinition: credDefObj,
+        credentialDefinition,
         tag: 'default',
         revocationRegistryType: 'CL_ACCUM',
         maximumCredentialNumber: 100,
       })
 
       const maximumCredentialNumber = indyCredx.revocationRegistryDefinitionGetAttribute({
-        objectHandle: revRegDef,
+        objectHandle: registryDefinition,
         name: 'max_cred_num',
       })
 
       expect(maximumCredentialNumber).toEqual('100')
-      const json = indyCredx.getJson({ objectHandle: revRegDef })
+      const json = indyCredx.getJson({ objectHandle: registryDefinition })
       expect(JSON.parse(json)).toEqual(
         expect.objectContaining({
           credDefId: '55GkHamhTU1ZbTbV2ab9DE:3:CL:1:TAG',
@@ -132,7 +131,7 @@ describe('bindings', () => {
           tag: 'default',
         })
       )
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+
       expect(JSON.parse(json).value).toEqual(
         expect.objectContaining({
           issuanceType: 'ISSUANCE_BY_DEFAULT',
@@ -145,7 +144,6 @@ describe('bindings', () => {
     const masterSecret = indyCredx.createMasterSecret()
     const json = indyCredx.getJson({ objectHandle: masterSecret })
     expect(JSON.parse(json)).toHaveProperty('value')
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(JSON.parse(json).value).toHaveProperty('ms')
   })
 
@@ -158,7 +156,7 @@ describe('bindings', () => {
       attributeNames: ['attr-1'],
     })
 
-    const [credDefObj, credDefPvt, keyProof] = indyCredx.createCredentialDefinition({
+    const { credentialDefinition, keyProof } = indyCredx.createCredentialDefinition({
       originDid: '55GkHamhTU1ZbTbV2ab9DE',
       schema: schemaObj,
       signatureType: 'CL',
@@ -168,7 +166,7 @@ describe('bindings', () => {
 
     const credOfferObj = indyCredx.createCredentialOffer({
       schemaId: '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1',
-      credentialDefinition: credDefObj,
+      credentialDefinition: credentialDefinition,
       keyProof,
     })
 
@@ -192,7 +190,7 @@ describe('bindings', () => {
       attributeNames: ['attr-1'],
     })
 
-    const [credDefObj, credDefPvt, keyProof] = indyCredx.createCredentialDefinition({
+    const { credentialDefinition, keyProof } = indyCredx.createCredentialDefinition({
       originDid: '55GkHamhTU1ZbTbV2ab9DE',
       schema: schemaObj,
       signatureType: 'CL',
@@ -202,22 +200,22 @@ describe('bindings', () => {
 
     const credOfferObj = indyCredx.createCredentialOffer({
       schemaId: '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1',
-      credentialDefinition: credDefObj,
+      credentialDefinition: credentialDefinition,
       keyProof,
     })
 
     const masterSecret = indyCredx.createMasterSecret()
     const masterSecretId = 'master secret id'
 
-    const [credReq, credReqMetadata] = indyCredx.createCredentialRequest({
+    const { credentialRequest, credentialRequestMeta } = indyCredx.createCredentialRequest({
       proverDid: '55GkHamhTU1ZbTbV2ab9DE',
-      credentialDefinition: credDefObj,
+      credentialDefinition: credentialDefinition,
       masterSecret,
       masterSecretId,
       credentialOffer: credOfferObj,
     })
 
-    const credReqJson = indyCredx.getJson({ objectHandle: credReq })
+    const credReqJson = indyCredx.getJson({ objectHandle: credentialRequest })
     expect(JSON.parse(credReqJson)).toEqual(
       expect.objectContaining({
         prover_did: '55GkHamhTU1ZbTbV2ab9DE',
@@ -226,7 +224,7 @@ describe('bindings', () => {
     expect(JSON.parse(credReqJson)).toHaveProperty('blinded_ms')
     expect(JSON.parse(credReqJson)).toHaveProperty('nonce')
 
-    const credReqMetadataJson = indyCredx.getJson({ objectHandle: credReqMetadata })
+    const credReqMetadataJson = indyCredx.getJson({ objectHandle: credentialRequestMeta })
     expect(JSON.parse(credReqMetadataJson)).toEqual(
       expect.objectContaining({
         master_secret_name: masterSecretId,
@@ -245,7 +243,7 @@ describe('bindings', () => {
       attributeNames: ['attr-1'],
     })
 
-    const [credDefObj, credDefPvt, keyProof] = indyCredx.createCredentialDefinition({
+    const { credentialDefinition, keyProof, credentialDefinitionPrivate } = indyCredx.createCredentialDefinition({
       originDid: '55GkHamhTU1ZbTbV2ab9DE',
       schema: schemaObj,
       signatureType: 'CL',
@@ -255,59 +253,59 @@ describe('bindings', () => {
 
     const credOfferObj = indyCredx.createCredentialOffer({
       schemaId: '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1',
-      credentialDefinition: credDefObj,
+      credentialDefinition: credentialDefinition,
       keyProof,
     })
 
     const masterSecret = indyCredx.createMasterSecret()
     const masterSecretId = 'master secret id'
 
-    const [credReq, credReqMetadata] = indyCredx.createCredentialRequest({
+    const { credentialRequestMeta, credentialRequest } = indyCredx.createCredentialRequest({
       proverDid: '55GkHamhTU1ZbTbV2ab9DE',
-      credentialDefinition: credDefObj,
+      credentialDefinition,
       masterSecret,
       masterSecretId,
       credentialOffer: credOfferObj,
     })
 
-    const [revRegDef, revRegDefPrivate, revReg, revRegInitDelta] = indyCredx.createRevocationRegistry({
+    const { registryDefinition, registryEntry, registryDefinitionPrivate } = indyCredx.createRevocationRegistry({
       originDid: '55GkHamhTU1ZbTbV2ab9DE',
-      credentialDefinition: credDefObj,
+      credentialDefinition,
       tag: 'default',
       revocationRegistryType: 'CL_ACCUM',
       maximumCredentialNumber: 100,
     })
 
     const tailsPath = indyCredx.revocationRegistryDefinitionGetAttribute({
-      objectHandle: revRegDef,
+      objectHandle: registryDefinition,
       name: 'tails_location',
     })
 
-    const [cred, revRegUpdated, revDelta] = indyCredx.createCredential({
-      credentialDefinition: credDefObj,
-      credentialDefinitionPrivate: credDefPvt,
+    const { credential } = indyCredx.createCredential({
+      credentialDefinition: credentialDefinition,
+      credentialDefinitionPrivate: credentialDefinitionPrivate,
       credentialOffer: credOfferObj,
-      credentialRequest: credReq,
+      credentialRequest: credentialRequest,
       attributeRawValues: { 'attr-1': 'test' },
       attributeEncodedValues: undefined,
       revocationConfiguration: {
-        registryDefinition: revRegDef,
-        registryDefinitionPrivate: revRegDefPrivate,
-        registry: revReg,
+        registryDefinition,
+        registryDefinitionPrivate,
+        registry: registryEntry,
         registryIndex: 1,
         tailsPath: tailsPath,
       },
     })
 
     const credReceived = indyCredx.processCredential({
-      credential: cred,
-      credentialDefinition: credDefObj,
-      credentialRequestMetadata: credReqMetadata,
+      credential,
+      credentialDefinition,
+      credentialRequestMetadata: credentialRequestMeta,
       masterSecret,
-      revocationRegistryDefinition: revRegDef,
+      revocationRegistryDefinition: registryDefinition,
     })
 
-    const credJson = indyCredx.getJson({ objectHandle: cred })
+    const credJson = indyCredx.getJson({ objectHandle: credential })
     expect(JSON.parse(credJson)).toEqual(
       expect.objectContaining({
         cred_def_id: '55GkHamhTU1ZbTbV2ab9DE:3:CL:1:TAG',
@@ -362,7 +360,7 @@ describe('bindings', () => {
       attributeNames: ['attr-1'],
     })
 
-    const [credDefObj, credDefPvt, keyProof] = indyCredx.createCredentialDefinition({
+    const { credentialDefinition, credentialDefinitionPrivate, keyProof } = indyCredx.createCredentialDefinition({
       originDid: '55GkHamhTU1ZbTbV2ab9DE',
       schema: schemaObj,
       signatureType: 'CL',
@@ -372,60 +370,61 @@ describe('bindings', () => {
 
     const credOfferObj = indyCredx.createCredentialOffer({
       schemaId: '55GkHamhTU1ZbTbV2ab9DE:2:schema-1:1',
-      credentialDefinition: credDefObj,
+      credentialDefinition,
       keyProof,
     })
 
     const masterSecret = indyCredx.createMasterSecret()
     const masterSecretId = 'master secret id'
 
-    const [credReq, credReqMetadata] = indyCredx.createCredentialRequest({
+    const { credentialRequest } = indyCredx.createCredentialRequest({
       proverDid: '55GkHamhTU1ZbTbV2ab9DE',
-      credentialDefinition: credDefObj,
+      credentialDefinition,
       masterSecret,
       masterSecretId,
       credentialOffer: credOfferObj,
     })
 
-    const [revRegDef, revRegDefPrivate, revReg, revRegInitDelta] = indyCredx.createRevocationRegistry({
-      originDid: '55GkHamhTU1ZbTbV2ab9DE',
-      credentialDefinition: credDefObj,
-      tag: 'default',
-      revocationRegistryType: 'CL_ACCUM',
-      maximumCredentialNumber: 100,
-    })
+    const { registryDefinition, registryEntry, registryDefinitionPrivate, registryInitDelta } =
+      indyCredx.createRevocationRegistry({
+        originDid: '55GkHamhTU1ZbTbV2ab9DE',
+        credentialDefinition,
+        tag: 'default',
+        revocationRegistryType: 'CL_ACCUM',
+        maximumCredentialNumber: 100,
+      })
 
     const tailsPath = indyCredx.revocationRegistryDefinitionGetAttribute({
-      objectHandle: revRegDef,
+      objectHandle: registryDefinition,
       name: 'tails_location',
     })
 
-    const [cred, revRegUpdated, revDelta] = indyCredx.createCredential({
-      credentialDefinition: credDefObj,
-      credentialDefinitionPrivate: credDefPvt,
+    const { credential } = indyCredx.createCredential({
+      credentialDefinition,
+      credentialDefinitionPrivate,
       credentialOffer: credOfferObj,
-      credentialRequest: credReq,
+      credentialRequest,
       attributeRawValues: { 'attr-1': 'test' },
       attributeEncodedValues: undefined,
       revocationConfiguration: {
-        registryDefinition: revRegDef,
-        registryDefinitionPrivate: revRegDefPrivate,
-        registry: revReg,
+        registryDefinition,
+        registryDefinitionPrivate,
+        registry: registryEntry,
         registryIndex: 1,
         tailsPath: tailsPath,
       },
     })
 
     const revRegIndex = indyCredx.credentialGetAttribute({
-      objectHandle: cred,
+      objectHandle: credential,
       name: 'rev_reg_index',
     })
 
     const revocationRegistryIndex = revRegIndex === null ? 0 : parseInt(revRegIndex)
 
     const revocationState = indyCredx.createOrUpdateRevocationState({
-      revocationRegistryDefinition: revRegDef,
-      revocationRegistryDelta: revRegInitDelta,
+      revocationRegistryDefinition: registryDefinition,
+      revocationRegistryDelta: registryInitDelta,
       revocationRegistryIndex,
       timestamp,
       tailsPath,
@@ -435,12 +434,12 @@ describe('bindings', () => {
       presentationRequest: presRequestObj,
       credentials: [
         {
-          credential: cred,
+          credential,
           revocationState,
           timestamp,
         },
       ],
-      credentialDefinitions: [credDefObj],
+      credentialDefinitions: [credentialDefinition],
       credentialsProve: [
         {
           entryIndex: 0,
@@ -457,11 +456,11 @@ describe('bindings', () => {
     const verify = indyCredx.verifyPresentation({
       presentation: presentationObj,
       presentationRequest: presRequestObj,
-      credentialDefinitions: [credDefObj],
-      revocationRegistryDefinitions: [revRegDef],
+      credentialDefinitions: [credentialDefinition],
+      revocationRegistryDefinitions: [registryDefinition],
       revocationEntries: [
         {
-          entry: revReg,
+          entry: registryEntry,
           revocationRegistryDefinitionEntryIndex: 0,
           timestamp,
         },

--- a/wrappers/javascript/nodejs/test/utils/initialize.ts
+++ b/wrappers/javascript/nodejs/test/utils/initialize.ts
@@ -2,6 +2,4 @@ import { registerIndyCredx } from 'indy-credx-shared'
 
 import { NodeJSIndyCredx } from '../../src/NodeJSIndyCredx'
 
-export const setup = () => {
-  registerIndyCredx({ credx: new NodeJSIndyCredx() })
-}
+export const setup = () => registerIndyCredx({ credx: new NodeJSIndyCredx() })

--- a/wrappers/javascript/nodejs/test/utils/initialize.ts
+++ b/wrappers/javascript/nodejs/test/utils/initialize.ts
@@ -1,5 +1,9 @@
 import { registerIndyCredx } from 'indy-credx-shared'
 
 import { NodeJSIndyCredx } from '../../src/NodeJSIndyCredx'
+import { nativeIndyCredx } from '../../src/library'
 
-export const setup = () => registerIndyCredx({ credx: new NodeJSIndyCredx() })
+export const setup = () => {
+  registerIndyCredx({ credx: new NodeJSIndyCredx() })
+  nativeIndyCredx.credx_set_default_logger()
+}

--- a/wrappers/javascript/nodejs/tsconfig.json
+++ b/wrappers/javascript/nodejs/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true,
     "types": ["node", "jest"]
   }
 }

--- a/wrappers/javascript/package.json
+++ b/wrappers/javascript/package.json
@@ -3,21 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "workspaces": {
-    "packages": [
-      "shared",
-      "nodejs",
-      "react-native"
-    ],
-    "nohoist": [
-      "**/react-native/**",
-      "react-native/**",
-      "react-native",
-      "**/react-native",
-      "**/react/**",
-      "react/**",
-      "react",
-      "**/react"
-    ]
+    "packages": ["shared", "nodejs", "react-native", "react-native-example"]
   },
   "scripts": {
     "lint": "eslint .",
@@ -44,9 +30,9 @@
     "@types/jest": "28.1.6",
     "@typescript-eslint/eslint-plugin": "5.11.0",
     "@typescript-eslint/parser": "5.11.0",
-    "eslint": "8.8.0",
+    "eslint": "8.22.0",
     "eslint-config-prettier": "8.3.0",
-    "eslint-import-resolver-typescript": "2.5.0",
+    "eslint-import-resolver-typescript": "3.5.0",
     "eslint-plugin-import": "2.25.4",
     "eslint-plugin-prettier": "4.0.0",
     "jest": "28.1.3",

--- a/wrappers/javascript/react-native/cpp/HostObject.cpp
+++ b/wrappers/javascript/react-native/cpp/HostObject.cpp
@@ -8,7 +8,6 @@ FunctionMap TurboModuleHostObject::functionMapping(jsi::Runtime &rt) {
   FunctionMap fMap;
 
   fMap.insert(std::make_tuple("version", &indyCredx::version));
-  fMap.insert(std::make_tuple("bufferFree", &indyCredx::bufferFree));
   fMap.insert(
       std::make_tuple("createCredential", &indyCredx::createCredential));
   fMap.insert(std::make_tuple("createCredentialDefinition",

--- a/wrappers/javascript/react-native/cpp/indyCredx.cpp
+++ b/wrappers/javascript/react-native/cpp/indyCredx.cpp
@@ -10,14 +10,6 @@ jsi::Value version(jsi::Runtime &rt, jsi::Object options) {
   return jsi::String::createFromAscii(rt, credx_version());
 };
 
-jsi::Value bufferFree(jsi::Runtime &rt, jsi::Object options) {
-  auto buffer = jsiToValue<ByteBuffer>(rt, options, "buffer");
-
-  credx_buffer_free(buffer);
-
-  return jsi::Value::null();
-};
-
 jsi::Value createCredential(jsi::Runtime &rt, jsi::Object options) {
   auto credDef = jsiToValue<ObjectHandle>(rt, options, "credDef");
   auto credDefPrivate = jsiToValue<ObjectHandle>(rt, options, "credDefPrivate");
@@ -28,104 +20,106 @@ jsi::Value createCredential(jsi::Runtime &rt, jsi::Object options) {
   auto attrEncValues = jsiToValue<FfiStrList>(rt, options, "attrEncValues");
   auto revocation = jsiToValue<FfiCredRevInfo>(rt, options, "revocation");
 
-  ObjectHandle credP;
-  ObjectHandle revRegP;
-  ObjectHandle revDeltaP;
+  ObjectHandle *credP;
+  ObjectHandle *revRegP;
+  ObjectHandle *revDeltaP;
 
   ErrorCode code = credx_create_credential(
-      credDef, credDefPrivate, credoffer, credRequest, attrNames, attrRawValues,
-      attrEncvalues, revocation, credP, revRegP, revDeltaP);
+      credDef, credDefPrivate, credOffer, credRequest, attrNames, attrRawValues,
+      attrEncValues, &revocation, credP, revRegP, revDeltaP);
   handleError(rt, code);
 
   jsi::Object object = jsi::Object(rt);
-  object.setProperty(rt, "cred", credP);
-  object.setProperty(rt, "revReg", revRegP);
-  object.setProperty(rt, "revDelta", revDeltaP);
+  object.setProperty(rt, "cred", int(*credP));
+  object.setProperty(rt, "revReg", int(*revRegP));
+  object.setProperty(rt, "revDelta", int(*revDeltaP));
   return object;
 };
 
 jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options) {
-  auto originDid = jsiToValue<FfiStr>(rt, options, "originDid");
+  auto originDid = jsiToValue<std::string>(rt, options, "originDid");
   auto schema = jsiToValue<ObjectHandle>(rt, options, "schema");
-  auto tag = jsiToValue<FfiStr>(rt, options, "tag");
-  auto signatureType = jsiToValue<FfiStr>(rt, options, "signatureType");
+  auto tag = jsiToValue<std::string>(rt, options, "tag");
+  auto signatureType = jsiToValue<std::string>(rt, options, "signatureType");
   auto supportRevocation = jsiToValue<int8_t>(rt, options, "supportRevocation");
 
-  ObjectHandle credDefP;
-  ObjectHandle credDefPvtP;
-  ObjectHandle keyProofP;
+  ObjectHandle *credDefP;
+  ObjectHandle *credDefPvtP;
+  ObjectHandle *keyProofP;
 
   ErrorCode code = credx_create_credential_definition(
-      originDid, schema, tag, signatureType, supportRevocation, credDefP,
-      credDefPvtP, keyProofP);
+      originDid.c_str(), schema, tag.c_str(), signatureType.c_str(),
+      supportRevocation, credDefP, credDefPvtP, keyProofP);
   handleError(rt, code);
 
   jsi::Object object = jsi::Object(rt);
-  object.setProperty(rt, "credDef", credDefP);
-  object.setProperty(rt, "credDevPvt", credDevPvtP);
-  object.setProperty(rt, "keyProof", keyProofP);
+  object.setProperty(rt, "credDef", int(*credDefP));
+  object.setProperty(rt, "credDevPvt", int(*credDefPvtP));
+  object.setProperty(rt, "keyProof", int(*keyProofP));
   return object;
 };
 
 jsi::Value createCredentialOffer(jsi::Runtime &rt, jsi::Object options) {
-  auto schemaId = jsiToValue<FfiStr>(rt, options, "schemaId");
+  auto schemaId = jsiToValue<std::string>(rt, options, "schemaId");
   auto credDef = jsiToValue<ObjectHandle>(rt, options, "credDef");
   auto keyProof = jsiToValue<ObjectHandle>(rt, options, "keyProof");
 
-  Objecthandle credOfferP;
+  ObjectHandle *credOfferP;
 
-  ErrorCode code =
-      credx_create_credential_offer(schemaId, credDef, keyProof, credOfferP);
+  ErrorCode code = credx_create_credential_offer(schemaId.c_str(), credDef,
+                                                 keyProof, credOfferP);
   handleError(rt, code);
 
-  return jsi::Value(credOfferP);
+  return jsi::Value(int(*credOfferP));
 };
 
 jsi::Value createCredentialRequest(jsi::Runtime &rt, jsi::Object options) {
-  auto proverDid = jsiToValue<FfiStr>(rt, options, "proverDid");
+  auto proverDid = jsiToValue<std::string>(rt, options, "proverDid");
   auto credDef = jsiToValue<ObjectHandle>(rt, options, "credDef");
   auto masterSecret = jsiToValue<ObjectHandle>(rt, options, "masterSecret");
-  auto masterSecretId = jsiToValue<FfiStr>(rt, options, "masterSecretId");
+  auto masterSecretId = jsiToValue<std::string>(rt, options, "masterSecretId");
   auto credOffer = jsiToValue<ObjectHandle>(rt, options, "credOffer");
 
-  Objecthandle credReqP;
-  Objecthandle credReqMetaP;
+  ObjectHandle *credReqP;
+  ObjectHandle *credReqMetaP;
 
   ErrorCode code = credx_create_credential_request(
-      proverDid, credDef, masterSecret, masterSecretId, credOffer, credReqP,
-      credReqMetaP);
+      proverDid.c_str(), credDef, masterSecret, masterSecretId.c_str(),
+      credOffer, credReqP, credReqMetaP);
   handleError(rt, code);
 
   jsi::Object object = jsi::Object(rt);
-  object.setProperty(rt, "credReq", credReqP);
-  object.setProperty(rt, "credReqMeta", credReqMetaP);
+  object.setProperty(rt, "credReq", int(*credReqP));
+  object.setProperty(rt, "credReqMeta", int(*credReqMetaP));
   return object;
 };
 
 jsi::Value createMasterSecret(jsi::Runtime &rt, jsi::Object options) {
-  ObjectHandle masterSecretP;
+  ObjectHandle *masterSecretP;
 
-  ErrorCode code = crex_create_master_secret(masterSecretP);
+  ErrorCode code = credx_create_master_secret(masterSecretP);
   handleError(rt, code);
 
-  return jsi::Value(masterSecretP);
+  return jsi::Value(int(*masterSecretP));
 };
 
 jsi::Value createOrUpdateRevocationState(jsi::Runtime &rt,
                                          jsi::Object options) {
   auto revRegDef = jsiToValue<ObjectHandle>(rt, options, "revRegDef");
   auto revRegDelta = jsiToValue<ObjectHandle>(rt, options, "revRegDelta");
+  auto revRegIndex = jsiToValue<int64_t>(rt, options, "revRegIndex");
   auto timestamp = jsiToValue<int64_t>(rt, options, "timestamp");
-  auto tailsPath = jsiToValue<FfiStr>(rt, options, "tailsPath");
+  auto tailsPath = jsiToValue<std::string>(rt, options, "tailsPath");
   auto revState = jsiToValue<ObjectHandle>(rt, options, "revState");
 
-  ObjectHandle revStateP;
+  ObjectHandle *revStateP;
 
   ErrorCode code = credx_create_or_update_revocation_state(
-      revRegDef, revRegDelta, timestamp, tailsPath, revState, revStateP);
+      revRegDef, revRegDelta, revRegIndex, timestamp, tailsPath.c_str(),
+      revState, revStateP);
   handleError(rt, code);
 
-  return jsi::Value(revStateP);
+  return jsi::Value(int(*revStateP));
 };
 
 jsi::Value createPresentation(jsi::Runtime &rt, jsi::Object options) {
@@ -141,82 +135,85 @@ jsi::Value createPresentation(jsi::Runtime &rt, jsi::Object options) {
   auto schemas = jsiToValue<FfiList_ObjectHandle>(rt, options, "schemas");
   auto credDefs = jsiToValue<FfiList_ObjectHandle>(rt, options, "credDefs");
 
-  ObjectHandle presentationP;
+  ObjectHandle *presentationP;
 
   ErrorCode code = credx_create_presentation(
       presReq, credentials, credentialsProve, selfAttestNames, selfAttestValues,
-      schemas, credDefs, presentationP);
+      masterSecret, schemas, credDefs, presentationP);
 
-  return jsi::Value(presentationP);
+  return jsi::Value(int(*presentationP));
 };
 
 jsi::Value createRevocationRegistry(jsi::Runtime &rt, jsi::Object options) {
-  auto originDid = jsiToValue<FfiStr>(rt, options, "originDid");
+  auto originDid = jsiToValue<std::string>(rt, options, "originDid");
   auto credDef = jsiToValue<ObjectHandle>(rt, options, "credDef");
-  auto tag = jsiToValue<FfiStr>(rt, options, "tag");
-  auto revRegType = jsiToValue<FfiStr>(rt, options, "revRegType");
-  auto issuanceType = jsiToValue<FfiStr>(rt, options, "issuanceType");
+  auto tag = jsiToValue<std::string>(rt, options, "tag");
+  auto revRegType = jsiToValue<std::string>(rt, options, "revRegType");
+  auto issuanceType = jsiToValue<std::string>(rt, options, "issuanceType");
   auto maxCredNum = jsiToValue<int64_t>(rt, options, "maxCredNum");
-  auto tailsDirPath = jsiToValue<FfiStr>(rt, options, "tailsDirPath");
+  auto tailsDirPath = jsiToValue<std::string>(rt, options, "tailsDirPath");
 
-  ObjectHandle regDefP;
-  ObjechHandle regDefPrivateP;
-  ObjectHandle regEntryP;
-  ObjectHandle regInitDeltaP;
+  ObjectHandle *regDefP;
+  ObjectHandle *regDefPrivateP;
+  ObjectHandle *regEntryP;
+  ObjectHandle *regInitDeltaP;
 
-  ErorCode code = credx_create_revocation_registry(
-      originDid, credDef, tag, revRegType, issuanceType, maxCredNum,
-      tailsDirPath, regDefP, regDefPrivateP, regEntryP, regInitDeltaP);
+  ErrorCode code = credx_create_revocation_registry(
+      originDid.c_str(), credDef, tag.c_str(), revRegType.c_str(),
+      issuanceType.c_str(), maxCredNum, tailsDirPath.c_str(), regDefP,
+      regDefPrivateP, regEntryP, regInitDeltaP);
   handleError(rt, code);
 
   jsi::Object object = jsi::Object(rt);
-  object.setProperty(rt, "regDef", regDefP);
-  object.setProperty(rt, "regDefPrivate", regDefPrivateP);
-  object.setProperty(rt, "regEntry", regEntryP);
-  object.setProperty(rt, "regInitDelta", regInitDeltaP);
+  object.setProperty(rt, "regDef", int(*regDefP));
+  object.setProperty(rt, "regDefPrivate", int(*regDefPrivateP));
+  object.setProperty(rt, "regEntry", int(*regEntryP));
+  object.setProperty(rt, "regInitDelta", int(*regInitDeltaP));
   return object;
 };
 
 jsi::Value createSchema(jsi::Runtime &rt, jsi::Object options) {
-  auto originDid = jsiToValue<FfiStr>(rt, options, "originDid");
-  auto schemaName = jsiToValue<FfiStr>(rt, options, "schemaName");
-  auto schemaVersion = jsiToValue<FfiStr>(rt, options, "schemaVersion");
+  auto originDid = jsiToValue<std::string>(rt, options, "originDid");
+  auto schemaName = jsiToValue<std::string>(rt, options, "schemaName");
+  auto schemaVersion = jsiToValue<std::string>(rt, options, "schemaVersion");
   auto attrNames = jsiToValue<FfiStrList>(rt, options, "attrNames");
   auto seqNo = jsiToValue<int64_t>(rt, options, "seqNo");
 
-  ObjectHandle resultP;
+  ObjectHandle *resultP;
 
-  ErrorCode code = credx_create_schema(originDid, schemaName, schemaVersion,
-                                       attrNames, seqNo, resultP);
+  ErrorCode code =
+      credx_create_schema(originDid.c_str(), schemaName.c_str(),
+                          schemaVersion.c_str(), attrNames, seqNo, resultP);
   handleError(rt, code);
 
-  return jsi::Value(resultP);
+  return jsi::Value(int(*resultP));
 };
 
 jsi::Value credentialDefinitionGetAttribute(jsi::Runtime &rt,
                                             jsi::Object options) {
   auto handle = jsiToValue<ObjectHandle>(rt, options, "handle");
-  auto name = jsiToValue<FfiStr>(rt, options, "name");
+  auto name = jsiToValue<std::string>(rt, options, "name");
 
   const char **resultP;
 
   ErrorCode code =
-      credx_credential_definition_get_attribute(handle, name, resultP);
+      credx_credential_definition_get_attribute(handle, name.c_str(), resultP);
   handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, resultP);
+  return jsi::String::createFromAscii(rt, "TODO");
 };
 
 jsi::Value credentialGetAttribute(jsi::Runtime &rt, jsi::Object options) {
   auto handle = jsiToValue<ObjectHandle>(rt, options, "handle");
-  auto name = jsiToValue<FfiStr>(rt, options, "name");
+  auto name = jsiToValue<std::string>(rt, options, "name");
 
   const char **resultP;
 
-  ErrorCode code = credx_credential_get_attribute(handle, name, resultP);
+  ErrorCode code =
+      credx_credential_get_attribute(handle, name.c_str(), resultP);
   handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, resultP);
+  return jsi::String::createFromAscii(rt, "TODO");
 };
 
 jsi::Value encodeCredentialAttributes(jsi::Runtime &rt, jsi::Object options) {
@@ -227,25 +224,25 @@ jsi::Value encodeCredentialAttributes(jsi::Runtime &rt, jsi::Object options) {
   ErrorCode code = credx_encode_credential_attributes(attrRawValues, resultP);
   handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, resultP);
+  return jsi::String::createFromAscii(rt, "TODO");
 };
 
 jsi::Value generateNonce(jsi::Runtime &rt, jsi::Object options) {
   const char **nonceP;
 
   ErrorCode code = credx_generate_nonce(nonceP);
-  handleError(rt code);
+  handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, nonceP);
+  return jsi::String::createFromAscii(rt, "TODO");
 };
 
 jsi::Value getCurrentError(jsi::Runtime &rt, jsi::Object options) {
   const char **errorJsonP;
 
   ErrorCode code = credx_get_current_error(errorJsonP);
-  handleError(rt code);
+  handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, errorJsonP);
+  return jsi::String::createFromAscii(rt, *errorJsonP);
 };
 
 jsi::Value mergeRevocationRegistryDeltas(jsi::Runtime &rt,
@@ -253,24 +250,25 @@ jsi::Value mergeRevocationRegistryDeltas(jsi::Runtime &rt,
   auto revRegDelta1 = jsiToValue<ObjectHandle>(rt, options, "revRegDelta1");
   auto revRegDelta2 = jsiToValue<ObjectHandle>(rt, options, "revRegDelta2");
 
-  ObjectHandle revRegDeltaP;
+  ObjectHandle *revRegDeltaP;
 
   ErrorCode code = credx_merge_revocation_registry_deltas(
       revRegDelta1, revRegDelta2, revRegDeltaP);
   handleError(rt, code);
 
-  return jsi::Value(revRegDeltaP);
+  return jsi::Value(int(*revRegDeltaP));
 };
 
 jsi::Value objectGetJson(jsi::Runtime &rt, jsi::Object options) {
   auto handle = jsiToValue<ObjectHandle>(rt, options, "handle");
 
-  ByteBuffer resultP;
+  ByteBuffer *resultP;
 
   ErrorCode code = credx_object_get_json(handle, resultP);
   handleError(rt, code);
 
-  return jsi::Value(resultP);
+  // TODO: ByteBuffer to string
+  return jsi::Value(0);
 };
 
 jsi::Value objectGetTypeName(jsi::Runtime &rt, jsi::Object options) {
@@ -281,7 +279,7 @@ jsi::Value objectGetTypeName(jsi::Runtime &rt, jsi::Object options) {
   ErrorCode code = credx_object_get_type_name(handle, resultP);
   handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, errorJsonP);
+  return jsi::String::createFromAscii(rt, *resultP);
 };
 
 jsi::Value processCredential(jsi::Runtime &rt, jsi::Object options) {
@@ -298,52 +296,52 @@ jsi::Value processCredential(jsi::Runtime &rt, jsi::Object options) {
                                             credDef, revRegDef, credP);
   handleError(rt, code);
 
-  return jsi::Value(credP);
+  return jsi::Value(int(*credP));
 };
 
 jsi::Value revocationRegistryDefinitionGetAttribute(jsi::Runtime &rt,
                                                     jsi::Object options) {
   auto handle = jsiToValue<ObjectHandle>(rt, options, "handle");
-  auto name = jsiToValue<FfiStr>(rt, options, "name");
+  auto name = jsiToValue<std::string>(rt, options, "name");
 
   const char **resultP;
 
   ErrorCode code =
-      credx_revocation_registry_definition_get_attrbute(handle, name, resultP);
+      credx_revocation_registry_definition_get_attribute(handle, name.c_str(), resultP);
   handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, resultP);
+  return jsi::String::createFromAscii(rt, *resultP);
 };
 
 jsi::Value revokeCredential(jsi::Runtime &rt, jsi::Object options) {
   auto revRegDef = jsiToValue<ObjectHandle>(rt, options, "revRegDef");
   auto revReg = jsiToValue<ObjectHandle>(rt, options, "revReg");
   auto credRevIdx = jsiToValue<int64_t>(rt, options, "credRevIdx");
-  auto tailsPath = jsiToValue<FfiStr>(rt, options, "tailsPath");
+  auto tailsPath = jsiToValue<std::string>(rt, options, "tailsPath");
 
   ObjectHandle *revRegP;
   ObjectHandle *revRegDeltaP;
 
   ErrorCode code = credx_revoke_credential(revRegDef, revReg, credRevIdx,
-                                           tailsPath, revRegP, revRegDeltaP);
+                                           tailsPath.c_str(), revRegP, revRegDeltaP);
   handleError(rt, code);
 
   jsi::Object object = jsi::Object(rt);
-  object.setProperty(rt, "revReg", revRegP);
-  object.setProperty(rt, "revRegDelta", revRegDeltaP);
+  object.setProperty(rt, "revReg", int(*revRegP));
+  object.setProperty(rt, "revRegDelta", int(*revRegDeltaP));
   return object;
 };
 
 jsi::Value schemaGetAttribute(jsi::Runtime &rt, jsi::Object options) {
   auto handle = jsiToValue<ObjectHandle>(rt, options, "handle");
-  auto name = jsiToValue<FfiStr>(rt, options, "name");
+  auto name = jsiToValue<std::string>(rt, options, "name");
 
   const char **resultP;
 
-  ErrorCode code = credx_schema_get_attribute(handle, name, resultP);
+  ErrorCode code = credx_schema_get_attribute(handle, name.c_str(), resultP);
   handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, resultP);
+  return jsi::String::createFromAscii(rt, *resultP);
 };
 
 jsi::Value setDefaultLogger(jsi::Runtime &rt, jsi::Object options) {
@@ -354,19 +352,20 @@ jsi::Value setDefaultLogger(jsi::Runtime &rt, jsi::Object options) {
 jsi::Value updateRevocationRegistry(jsi::Runtime &rt, jsi::Object options) {
   auto revRegDef = jsiToValue<ObjectHandle>(rt, options, "revRegDef");
   auto revReg = jsiToValue<ObjectHandle>(rt, options, "revReg");
-  auto issued = jsiToValue<FfiList_i64>(rt, options, "revoked");
-  auto tailsPath = jsiToValue<FfiStr>(rt, options, "tailsPath");
+  auto issued = jsiToValue<FfiList_i64>(rt, options, "issued");
+  auto revoked = jsiToValue<FfiList_i64>(rt, options, "revoked");
+  auto tailsPath = jsiToValue<std::string>(rt, options, "tailsPath");
 
-  ObjectHanlde *revRegP;
-  ObjectHanlde *revRegDeltaP;
+  ObjectHandle *revRegP;
+  ObjectHandle *revRegDeltaP;
 
   ErrorCode code = credx_update_revocation_registry(
-      revRegDef, revReg, issued, tailsPath, revRegP, revRegDeltaP);
+      revRegDef, revReg, issued, revoked, tailsPath.c_str(), revRegP, revRegDeltaP);
   handleError(rt, code);
 
   jsi::Object object = jsi::Object(rt);
-  object.setProperty(rt, "revReg", revRegP);
-  object.setProperty(rt, "revRegDelta", revRegDeltaP);
+  object.setProperty(rt, "revReg", int(*revRegP));
+  object.setProperty(rt, "revRegDelta", int(*revRegDeltaP));
   return object;
 }
 
@@ -386,7 +385,7 @@ jsi::Value verifyPresentation(jsi::Runtime &rt, jsi::Object options) {
                                 revRegDefs, revRegEntries, resultP);
   handleError(rt, code);
 
-  return jsi::Value(resultP);
+  return jsi::Value(int(*resultP));
 };
 
 jsi::Value objectFree(jsi::Runtime &rt, jsi::Object options) {

--- a/wrappers/javascript/react-native/cpp/indyCredx.h
+++ b/wrappers/javascript/react-native/cpp/indyCredx.h
@@ -9,7 +9,6 @@ using namespace facebook;
 namespace indyCredx {
 
 jsi::Value version(jsi::Runtime &rt, jsi::Object options);
-jsi::Value bufferFree(jsi::Runtime &rt, jsi::Object options);
 jsi::Value createCredential(jsi::Runtime &rt, jsi::Object options);
 jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options);
 jsi::Value createCredentialOffer(jsi::Runtime &rt, jsi::Object options);

--- a/wrappers/javascript/react-native/cpp/turboModuleUtility.cpp
+++ b/wrappers/javascript/react-native/cpp/turboModuleUtility.cpp
@@ -2,6 +2,8 @@
 
 #include <turboModuleUtility.h>
 
+
+
 namespace turboModuleUtility {
 
 using byteVector = std::vector<uint8_t>;
@@ -164,19 +166,309 @@ jsiToValue<std::vector<int32_t>>(jsi::Runtime &rt, jsi::Object &options,
 }
 
 template <>
-ByteBuffer jsiToValue<ByteBuffer>(jsi::Runtime &rt, jsi::Object &options,
-                                  const char *name, bool optional) {
+ObjectHandle jsiToValue(jsi::Runtime &rt, jsi::Object &options,
+                        const char *name, bool optional) {
+  jsi::Value value = options.getProperty(rt, name);
+  if ((value.isNull() || value.isUndefined()) && optional)
+    return 0;
+
+  if (value.isNumber())
+    return value.asNumber();
+
+  throw jsi::JSError(rt,
+                     errorPrefix + name + errorInfix + "ObjectHandle.handle");
+};
+
+template <>
+FfiRevocationEntry jsiToValue(jsi::Runtime &rt, jsi::Object &options,
+                              const char *name, bool optional) {
+  jsi::Value value = options.getProperty(rt, name);
+  if ((value.isNull() || value.isUndefined()) && optional)
+    return FfiRevocationEntry{};
+
+  if (value.isObject()) {
+    jsi::Object valueAsObject = value.asObject(rt);
+    auto revocationRegistryDefinitionIndex = jsiToValue<int64_t>(
+        rt, valueAsObject, "revocationRegistryDefinitionIndex");
+    auto entry = jsiToValue<ObjectHandle>(rt, valueAsObject, "entry");
+    auto timestamp = jsiToValue<int64_t>(rt, valueAsObject, "timestamp");
+
+    return FfiRevocationEntry{.timestamp = timestamp,
+                              .def_entry_idx =
+                                  revocationRegistryDefinitionIndex,
+                              .entry = entry};
+  }
+
+  throw jsi::JSError(rt, errorPrefix + name + errorInfix + "RevocationEntry");
+};
+
+
+
+template <>
+FfiCredentialEntry jsiToValue(jsi::Runtime &rt, jsi::Object &options,
+                              const char *name, bool optional) {
+  jsi::Value value = options.getProperty(rt, name);
+  if ((value.isNull() || value.isUndefined()) && optional)
+    return FfiCredentialEntry{};
+
+  if (value.isObject()) {
+    jsi::Object valueAsObject = value.asObject(rt);
+    auto credential = jsiToValue<ObjectHandle>(rt, valueAsObject, "credential");
+    auto timestamp = jsiToValue<int64_t>(rt, valueAsObject, "timestamp");
+    auto revocationState =
+        jsiToValue<ObjectHandle>(rt, valueAsObject, "revocationState");
+
+    return FfiCredentialEntry{.credential = credential,
+                              .timestamp = timestamp,
+                              .rev_state = revocationState};
+  }
+
+  throw jsi::JSError(rt, errorPrefix + name + errorInfix +
+                             "CredentialEntry");
+};
+
+template <>
+FfiCredentialProve jsiToValue(jsi::Runtime &rt, jsi::Object &options,
+                              const char *name, bool optional) {
+  jsi::Value value = options.getProperty(rt, name);
+  if ((value.isNull() || value.isUndefined()) && optional)
+    return FfiCredentialProve{};
+
+  if (value.isObject()) {
+    jsi::Object valueAsObject = value.asObject(rt);
+    auto entryIndex = jsiToValue<int64_t>(rt, valueAsObject, "entryIndex");
+    auto referent = jsiToValue<std::string>(rt, valueAsObject, "referent");
+    auto isPredicate = jsiToValue<int8_t>(rt, valueAsObject, "isPredicate");
+    auto reveal = jsiToValue<int8_t>(rt, valueAsObject, "reveal");
+
+    return FfiCredentialProve{.entry_idx = entryIndex,
+                              .is_predicate = isPredicate,
+                              .referent = referent.c_str(),
+                              .reveal = reveal};
+  }
+
+  throw jsi::JSError(rt, errorPrefix + name + errorInfix +
+                             "CredentialProve");
+};
+
+template <>
+FfiList_FfiRevocationEntry
+jsiToValue<FfiList_FfiRevocationEntry>(jsi::Runtime &rt, jsi::Object &options, const char *name, bool optional) {
   jsi::Value value = options.getProperty(rt, name);
 
-  if (value.isObject() && value.asObject(rt).isArrayBuffer(rt)) {
-    jsi::ArrayBuffer arrayBuffer = value.getObject(rt).getArrayBuffer(rt);
-    return ByteBuffer{int(arrayBuffer.size(rt)), arrayBuffer.data(rt)};
+  if (value.isObject() && value.asObject(rt).isArray(rt)) {
+    auto arr = value.asObject(rt).asArray(rt);
+    auto len = arr.length(rt);
+
+    auto revocationEntry = new FfiRevocationEntry[arrayMaxSize];
+    auto ret = FfiList_FfiRevocationEntry {.count=len, .data=revocationEntry};
+      
+    // TODO: error Handling
+    for (int i = 0; i < len; i++) {
+      auto element = arr.getValueAtIndex(rt, i);
+      auto valueAsObject = element.asObject(rt);
+        
+      auto revocationRegistryDefinitionIndex = jsiToValue<int64_t>(rt, valueAsObject, "revocationRegistryDefinitionIndex");
+      auto entry = jsiToValue<ObjectHandle>(rt, valueAsObject, "entry");
+      auto timestamp = jsiToValue<int64_t>(rt, valueAsObject, "timestamp");
+        
+      revocationEntry[i] = FfiRevocationEntry {.timestamp=timestamp, .entry=entry, .def_entry_idx=revocationRegistryDefinitionIndex};
+    }
+    return ret;
   }
 
   if (optional)
-    return ByteBuffer{0, 0};
+      return FfiList_FfiRevocationEntry {};
 
-  throw jsi::JSError(rt, errorPrefix + name + errorInfix + "Uint8Array");
+  throw jsi::JSError(rt, errorPrefix + name + errorInfix + "Array<number>");
 }
+
+template <>
+FfiList_FfiCredentialEntry
+jsiToValue<FfiList_FfiCredentialEntry>(jsi::Runtime &rt, jsi::Object &options, const char *name, bool optional) {
+  jsi::Value value = options.getProperty(rt, name);
+
+  if (value.isObject() && value.asObject(rt).isArray(rt)) {
+    auto arr = value.asObject(rt).asArray(rt);
+    auto len = arr.length(rt);
+
+    auto credentialEntry = new FfiCredentialEntry[arrayMaxSize];
+    auto ret = FfiList_FfiCredentialEntry {.count=len, .data=credentialEntry};
+      
+    // TODO: error Handling
+    for (int i = 0; i < len; i++) {
+      auto element = arr.getValueAtIndex(rt, i);
+      auto valueAsObject = element.asObject(rt);
+        
+        auto credential = jsiToValue<ObjectHandle>(rt, valueAsObject, "credential");
+        auto timestamp = jsiToValue<int64_t>(rt, valueAsObject, "timestamp");
+        auto revocationState =
+            jsiToValue<ObjectHandle>(rt, valueAsObject, "revocationState");
+
+        credentialEntry[i] =  FfiCredentialEntry{.credential = credential,
+                                  .timestamp = timestamp,
+                                  .rev_state = revocationState};
+    }
+    return ret;
+  }
+
+  if (optional)
+      return FfiList_FfiCredentialEntry {};
+
+  throw jsi::JSError(rt, errorPrefix + name + errorInfix + "Array<number>");
+}
+
+template <>
+FfiList_FfiCredentialProve
+jsiToValue<FfiList_FfiCredentialProve>(jsi::Runtime &rt, jsi::Object &options, const char *name, bool optional) {
+  jsi::Value value = options.getProperty(rt, name);
+
+  if (value.isObject() && value.asObject(rt).isArray(rt)) {
+    auto arr = value.asObject(rt).asArray(rt);
+    auto len = arr.length(rt);
+
+    auto credentialProve = new FfiCredentialProve[arrayMaxSize];
+    auto ret = FfiList_FfiCredentialProve {.count=len, .data=credentialProve};
+      
+    // TODO: error Handling
+    for (int i = 0; i < len; i++) {
+      auto element = arr.getValueAtIndex(rt, i);
+      auto valueAsObject = element.asObject(rt);
+        
+        auto entryIndex = jsiToValue<int64_t>(rt, valueAsObject, "entryIndex");
+        auto referent = jsiToValue<std::string>(rt, valueAsObject, "referent");
+        auto isPredicate = jsiToValue<int8_t>(rt, valueAsObject, "isPredicate");
+        auto reveal = jsiToValue<int8_t>(rt, valueAsObject, "reveal");
+
+        credentialProve[i] = FfiCredentialProve{.entry_idx = entryIndex,
+                                  .is_predicate = isPredicate,
+                                  .referent = referent.c_str(),
+                                  .reveal = reveal};
+    }
+    return ret;
+  }
+
+  if (optional)
+      return FfiList_FfiCredentialProve {};
+
+  throw jsi::JSError(rt, errorPrefix + name + errorInfix + "Array<number>");
+}
+
+template <>
+FfiList_ObjectHandle
+jsiToValue<FfiList_ObjectHandle>(jsi::Runtime &rt, jsi::Object &options, const char *name, bool optional) {
+  jsi::Value value = options.getProperty(rt, name);
+
+  if (value.isObject() && value.asObject(rt).isArray(rt)) {
+    auto arr = value.asObject(rt).asArray(rt);
+    auto len = arr.length(rt);
+
+    auto objectHandle = new ObjectHandle[arrayMaxSize];
+    auto ret = FfiList_ObjectHandle {.count=len, .data=objectHandle};
+      
+    // TODO: error Handling
+    for (int i = 0; i < len; i++) {
+      auto element = arr.getValueAtIndex(rt, i);
+      auto valueAsNumber = element.asNumber();
+
+        objectHandle[i] = size_t(valueAsNumber);
+    }
+    return ret;
+  }
+
+  if (optional)
+      return FfiList_ObjectHandle {};
+
+  throw jsi::JSError(rt, errorPrefix + name + errorInfix + "Array<number>");
+}
+
+template <>
+FfiList_FfiStr
+jsiToValue<FfiList_FfiStr>(jsi::Runtime &rt, jsi::Object &options, const char *name, bool optional) {
+  jsi::Value value = options.getProperty(rt, name);
+
+  if (value.isObject() && value.asObject(rt).isArray(rt)) {
+    auto arr = value.asObject(rt).asArray(rt);
+    auto len = arr.length(rt);
+
+    auto ffiStr = new FfiStr[arrayMaxSize];
+    auto ret = FfiList_FfiStr {.count=len, .data=ffiStr};
+      
+    // TODO: error Handling
+    for (int i = 0; i < len; i++) {
+      auto element = arr.getValueAtIndex(rt, i);
+      auto valueAsString = element.asString(rt);
+      std::string s = valueAsString.utf8(rt);
+
+      ffiStr[i] = s.c_str();
+    }
+    return ret;
+  }
+
+  if (optional)
+      return FfiList_FfiStr {};
+
+  throw jsi::JSError(rt, errorPrefix + name + errorInfix + "Array<number>");
+}
+
+template <>
+FfiList_i64
+jsiToValue<FfiList_i64>(jsi::Runtime &rt, jsi::Object &options, const char *name, bool optional) {
+  jsi::Value value = options.getProperty(rt, name);
+
+  if (value.isObject() && value.asObject(rt).isArray(rt)) {
+    auto arr = value.asObject(rt).asArray(rt);
+    auto len = arr.length(rt);
+
+    auto num = new int64_t[arrayMaxSize];
+    auto ret = FfiList_i64 {.count=len, .data=num};
+      
+    // TODO: error Handling
+    for (int i = 0; i < len; i++) {
+      auto element = arr.getValueAtIndex(rt, i);
+      auto valueAsNumber = element.asNumber();
+
+      num[i] = int64_t(valueAsNumber);
+    }
+    return ret;
+  }
+
+  if (optional)
+      return FfiList_i64 {};
+
+  throw jsi::JSError(rt, errorPrefix + name + errorInfix + "Array<number>");
+}
+
+template <>
+FfiCredRevInfo jsiToValue(jsi::Runtime &rt, jsi::Object &options,
+                          const char *name, bool optional) {
+  jsi::Value value = options.getProperty(rt, name);
+  if ((value.isNull() || value.isUndefined()) && optional)
+    return FfiCredRevInfo{};
+
+  if (value.isObject()) {
+    jsi::Object valueAsObject = value.asObject(rt);
+    auto registryDefinition =
+        jsiToValue<ObjectHandle>(rt, valueAsObject, "registryDefinition");
+    auto registryDefinitionPrivate = jsiToValue<ObjectHandle>(
+        rt, valueAsObject, "registryDefinitionPrivate");
+    auto registry = jsiToValue<ObjectHandle>(rt, valueAsObject, "registry");
+    auto registryIndex =
+        jsiToValue<int64_t>(rt, valueAsObject, "registryIndex");
+    auto registryUsed =
+        jsiToValue<FfiList_i64>(rt, valueAsObject, "registryUsed", true);
+    auto tailsPath = jsiToValue<std::string>(rt, valueAsObject, "tailsPath");
+
+    return FfiCredRevInfo{.reg_def = registryDefinition,
+                          .reg_def_private = registryDefinitionPrivate,
+                          .registry = registry,
+                          .reg_idx = registryIndex,
+                          .tails_path = tailsPath.c_str(),
+                          .reg_used = registryUsed};
+  }
+
+  throw jsi::JSError(rt, errorPrefix + name + errorInfix +
+                             "CredentialRevocationConfig");
+};
 
 } // namespace turboModuleUtility

--- a/wrappers/javascript/react-native/cpp/turboModuleUtility.h
+++ b/wrappers/javascript/react-native/cpp/turboModuleUtility.h
@@ -9,7 +9,7 @@
 using namespace facebook;
 
 namespace turboModuleUtility {
-
+static const int32_t arrayMaxSize = 255;
 static const std::string errorPrefix = "Value `";
 static const std::string errorInfix = "` is not of type ";
 

--- a/wrappers/javascript/react-native/package.json
+++ b/wrappers/javascript/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indy-credx-react-native",
-  "version": "0.0.0",
+  "version": "0.0.3",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Indy Credx",
   "main": "build/index",

--- a/wrappers/javascript/react-native/src/ReactNativeIndyCredx.ts
+++ b/wrappers/javascript/react-native/src/ReactNativeIndyCredx.ts
@@ -5,6 +5,7 @@ import type {
   NativeCredentialRevocationConfig,
   NativeRevocationEntry,
 } from 'indy-credx-shared'
+
 import { ObjectHandle } from 'indy-credx-shared'
 
 import { indyCredxReactNative } from './library'
@@ -28,7 +29,7 @@ export class ReactNativeIndyCredx implements IndyCredx {
     name: string
     version: string
     attributeNames: string[]
-    sequenceNumber?: number | undefined
+    sequenceNumber?: number
   }): ObjectHandle {
     const handle = indyCredxReactNative.createSchema(serializeArguments(options))
     return new ObjectHandle(handle)
@@ -40,9 +41,15 @@ export class ReactNativeIndyCredx implements IndyCredx {
     tag: string
     signatureType: string
     supportRevocation: boolean
-  }): [ObjectHandle, ObjectHandle, ObjectHandle] {
-    const [handle1, handle2, handle3] = indyCredxReactNative.createCredentialDefinition(serializeArguments(options))
-    return [new ObjectHandle(handle1), new ObjectHandle(handle2), new ObjectHandle(handle3)]
+  }): { credentialDefinition: ObjectHandle; credentialDefinitionPrivate: ObjectHandle; keyProof: ObjectHandle } {
+    const { keyProof, credentialDefinition, credentialDefinitionPrivate } =
+      indyCredxReactNative.createCredentialDefinition(serializeArguments(options))
+
+    return {
+      credentialDefinitionPrivate: new ObjectHandle(credentialDefinitionPrivate),
+      credentialDefinition: new ObjectHandle(credentialDefinition),
+      keyProof: new ObjectHandle(keyProof),
+    }
   }
 
   public createCredential(options: {
@@ -51,11 +58,18 @@ export class ReactNativeIndyCredx implements IndyCredx {
     credentialOffer: ObjectHandle
     credentialRequest: ObjectHandle
     attributeRawValues: Record<string, string>
-    attributeEncodedValues?: Record<string, string> | undefined
-    revocationConfiguration?: NativeCredentialRevocationConfig | undefined
-  }): [ObjectHandle, ObjectHandle, ObjectHandle] {
-    const [handle1, handle2, handle3] = indyCredxReactNative.createCredential(serializeArguments(options))
-    return [new ObjectHandle(handle1), new ObjectHandle(handle2), new ObjectHandle(handle3)]
+    attributeEncodedValues?: Record<string, string>
+    revocationConfiguration?: NativeCredentialRevocationConfig
+  }): { credential: ObjectHandle; revocationRegistry: ObjectHandle; revocationDelta: ObjectHandle } {
+    const { credential, revocationDelta, revocationRegistry } = indyCredxReactNative.createCredential(
+      serializeArguments(options)
+    )
+
+    return {
+      revocationRegistry: new ObjectHandle(revocationRegistry),
+      credential: new ObjectHandle(credential),
+      revocationDelta: new ObjectHandle(revocationDelta),
+    }
   }
 
   public encodeCredentialAttributes(attributeRawValues: Record<string, string>): Record<string, string> {
@@ -67,7 +81,7 @@ export class ReactNativeIndyCredx implements IndyCredx {
     credentialRequestMetadata: ObjectHandle
     masterSecret: ObjectHandle
     credentialDefinition: ObjectHandle
-    revocationRegistryDefinition?: ObjectHandle | undefined
+    revocationRegistryDefinition?: ObjectHandle
   }): ObjectHandle {
     const handle = indyCredxReactNative.processCredential(serializeArguments(options))
     return new ObjectHandle(handle)
@@ -78,9 +92,15 @@ export class ReactNativeIndyCredx implements IndyCredx {
     revocationRegistry: ObjectHandle
     credentialRevocationIndex: number
     tailsPath: string
-  }): [ObjectHandle, ObjectHandle] {
-    const [handle1, handle2] = indyCredxReactNative.revokeCredential(serializeArguments(options))
-    return [new ObjectHandle(handle1), new ObjectHandle(handle2)]
+  }): { revocationRegistry: ObjectHandle; revocationRegistryDelta: ObjectHandle } {
+    const { revocationRegistry, revocationRegistryDelta } = indyCredxReactNative.revokeCredential(
+      serializeArguments(options)
+    )
+
+    return {
+      revocationRegistryDelta: new ObjectHandle(revocationRegistryDelta),
+      revocationRegistry: new ObjectHandle(revocationRegistry),
+    }
   }
 
   public createCredentialOffer(options: {
@@ -98,9 +118,15 @@ export class ReactNativeIndyCredx implements IndyCredx {
     masterSecret: ObjectHandle
     masterSecretId: string
     credentialOffer: ObjectHandle
-  }): [ObjectHandle, ObjectHandle] {
-    const [handle1, handle2] = indyCredxReactNative.createCredentialRequest(serializeArguments(options))
-    return [new ObjectHandle(handle1), new ObjectHandle(handle2)]
+  }): { credentialRequest: ObjectHandle; credentialRequestMeta: ObjectHandle } {
+    const { credentialRequest, credentialRequestMeta } = indyCredxReactNative.createCredentialRequest(
+      serializeArguments(options)
+    )
+
+    return {
+      credentialRequestMeta: new ObjectHandle(credentialRequestMeta),
+      credentialRequest: new ObjectHandle(credentialRequest),
+    }
   }
 
   public createMasterSecret(): ObjectHandle {
@@ -137,14 +163,24 @@ export class ReactNativeIndyCredx implements IndyCredx {
     credentialDefinition: ObjectHandle
     tag: string
     revocationRegistryType: string
-    issuanceType?: string | undefined
+    issuanceType?: string
     maximumCredentialNumber: number
-    tailsDirectoryPath?: string | undefined
-  }): [ObjectHandle, ObjectHandle, ObjectHandle, ObjectHandle] {
-    const [handle1, handle2, handle3, handle4] = indyCredxReactNative.createRevocationRegistry(
-      serializeArguments(options)
-    )
-    return [new ObjectHandle(handle1), new ObjectHandle(handle2), new ObjectHandle(handle3), new ObjectHandle(handle4)]
+    tailsDirectoryPath?: string
+  }): {
+    registryDefinition: ObjectHandle
+    registryDefinitionPrivate: ObjectHandle
+    registryEntry: ObjectHandle
+    registryInitDelta: ObjectHandle
+  } {
+    const { registryEntry, registryInitDelta, registryDefinition, registryDefinitionPrivate } =
+      indyCredxReactNative.createRevocationRegistry(serializeArguments(options))
+
+    return {
+      registryDefinitionPrivate: new ObjectHandle(registryDefinitionPrivate),
+      registryDefinition: new ObjectHandle(registryDefinition),
+      registryInitDelta: new ObjectHandle(registryInitDelta),
+      registryEntry: new ObjectHandle(registryEntry),
+    }
   }
 
   public updateRevocationRegistry(options: {
@@ -153,9 +189,15 @@ export class ReactNativeIndyCredx implements IndyCredx {
     issued: number[]
     revoked: number[]
     tailsDirectoryPath: string
-  }): [ObjectHandle, ObjectHandle] {
-    const [handle1, handle2] = indyCredxReactNative.updateRevocationRegistry(serializeArguments(options))
-    return [new ObjectHandle(handle1), new ObjectHandle(handle2)]
+  }): { revocationRegistry: ObjectHandle; revocationRegistryDelta: ObjectHandle } {
+    const { revocationRegistry, revocationRegistryDelta } = indyCredxReactNative.updateRevocationRegistry(
+      serializeArguments(options)
+    )
+
+    return {
+      revocationRegistryDelta: new ObjectHandle(revocationRegistryDelta),
+      revocationRegistry: new ObjectHandle(revocationRegistry),
+    }
   }
 
   public mergeRevocationRegistryDeltas(options: {
@@ -172,7 +214,7 @@ export class ReactNativeIndyCredx implements IndyCredx {
     revocationRegistryIndex: number
     timestamp: number
     tailsPath: string
-    previousRevocationState?: ObjectHandle | undefined
+    previousRevocationState?: ObjectHandle
   }): ObjectHandle {
     const handle = indyCredxReactNative.createOrUpdateRevocationState(serializeArguments(options))
     return new ObjectHandle(handle)

--- a/wrappers/javascript/react-native/src/index.ts
+++ b/wrappers/javascript/react-native/src/index.ts
@@ -7,7 +7,6 @@ type Module = {
 const module = NativeModules.IndyCredx as Module
 if (!module.install()) throw Error('Unable to install the turboModule: IndyCredx')
 
-// Reexport everything from shared
 export * from 'indy-credx-shared'
 
 export { ReactNativeIndyCredx } from './ReactNativeIndyCredx'

--- a/wrappers/javascript/react-native/src/library/NativeBindings.ts
+++ b/wrappers/javascript/react-native/src/library/NativeBindings.ts
@@ -1,12 +1,11 @@
-import {
-  number,
+import type {
   NativeCredentialEntry,
   NativeCredentialProve,
   NativeRevocationEntry,
   NativeCredentialRevocationConfig,
 } from 'indy-credx-shared'
 
-// Alias for _Handle
+// Alias for _Handle.handle
 type _Handle = number
 
 export interface NativeBindings {
@@ -18,7 +17,7 @@ export interface NativeBindings {
     name: string
     version: string
     attributeNames: string[]
-    sequenceNumber?: number | undefined
+    sequenceNumber?: number
   }): _Handle
   createCredentialDefinition(options: {
     originDid: string
@@ -26,30 +25,30 @@ export interface NativeBindings {
     tag: string
     signatureType: string
     supportRevocation: number
-  }): [_Handle, _Handle, _Handle]
+  }): { credentialDefinition: _Handle; credentialDefinitionPrivate: _Handle; keyProof: _Handle }
   createCredential(options: {
     credentialDefinition: number
     credentialDefinitionPrivate: number
     credentialOffer: number
     credentialRequest: number
     attributeRawValues: string
-    attributeEncodedValues?: string | undefined
-    revocationConfiguration?: string | undefined
-  }): [_Handle, _Handle, _Handle]
+    attributeEncodedValues?: string
+    revocationConfiguration?: NativeCredentialRevocationConfig
+  }): { credential: _Handle; revocationRegistry: _Handle; revocationDelta: _Handle }
   encodeCredentialAttributes(options: { attributeRawValues: string }): Record<string, string>
   processCredential(options: {
     credential: number
     credentialRequestMetadata: number
     masterSecret: number
     credentialDefinition: number
-    revocationRegistryDefinition?: number | undefined
+    revocationRegistryDefinition?: number
   }): _Handle
   revokeCredential(options: {
     revocationRegistryDefinition: number
     revocationRegistry: number
     credentialRevocationIndex: number
     tailsPath: string
-  }): [_Handle, _Handle]
+  }): { revocationRegistry: _Handle; revocationRegistryDelta: _Handle }
 
   createCredentialOffer(options: { schemaId: string; credentialDefinition: number; keyProof: number }): _Handle
 
@@ -59,14 +58,14 @@ export interface NativeBindings {
     masterSecret: number
     masterSecretId: string
     credentialOffer: number
-  }): [_Handle, _Handle]
+  }): { credentialRequest: _Handle; credentialRequestMeta: _Handle }
 
   createMasterSecret(options: Record<never, never>): number
 
   createPresentation(options: {
     presentationRequest: number
-    credentials: string[]
-    credentialsProve: string[]
+    credentials: NativeCredentialEntry[]
+    credentialsProve: NativeCredentialProve[]
     selfAttest: string
     masterSecret: number
     schemas: number[]
@@ -79,7 +78,7 @@ export interface NativeBindings {
     schemas: number[]
     credentialDefinitions: number[]
     revocationRegistryDefinitions: number[]
-    revocationEntries: string[]
+    revocationEntries: NativeRevocationEntry[]
   }): boolean
 
   createRevocationRegistry(options: {
@@ -87,10 +86,15 @@ export interface NativeBindings {
     credentialDefinition: number
     tag: string
     revocationRegistryType: string
-    issuanceType?: string | undefined
+    issuanceType?: string
     maximumCredentialNumber: number
-    tailsDirectoryPath?: string | undefined
-  }): [_Handle, _Handle, _Handle, _Handle]
+    tailsDirectoryPath?: string
+  }): {
+    registryDefinition: _Handle
+    registryDefinitionPrivate: _Handle
+    registryEntry: _Handle
+    registryInitDelta: _Handle
+  }
 
   updateRevocationRegistry(options: {
     revocationRegistryDefinition: number
@@ -98,7 +102,7 @@ export interface NativeBindings {
     issued: number[]
     revoked: number[]
     tailsDirectoryPath: string
-  }): [number, _Handle]
+  }): { revocationRegistry: _Handle; revocationRegistryDelta: _Handle }
 
   mergeRevocationRegistryDeltas(options: {
     revocationRegistryDelta1: number
@@ -111,7 +115,7 @@ export interface NativeBindings {
     revocationRegistryIndex: number
     timestamp: number
     tailsPath: string
-    previousRevocationState?: number | undefined
+    previousRevocationState?: number
   }): _Handle
   presentationRequestFromJson(options: { json: string }): _Handle
   schemaGetAttribute(options: { objectHandle: number; name: string }): string

--- a/wrappers/javascript/react-native/src/utils/serialize.ts
+++ b/wrappers/javascript/react-native/src/utils/serialize.ts
@@ -1,65 +1,31 @@
 import { ObjectHandle } from 'indy-credx-shared'
 
-export type Callback = (err: number) => void
-export type CallbackWithResponse = (err: number, response: string) => void
+type Argument = SerializedArgument | Date | boolean | ObjectHandle
 
-type Argument =
-  | Record<string, unknown>
-  | Array<unknown>
-  | Date
-  | Uint8Array
-  | SerializedArgument
-  | boolean
-  | ObjectHandle
-
-type SerializedArgument = string | number | Callback | CallbackWithResponse | ArrayBuffer | Array<number>
+type SerializedArgument = string | number | Array<unknown> | Record<string, unknown>
 
 type SerializedArguments = Record<string, SerializedArgument>
 
 export type SerializedOptions<Type> = {
   [Property in keyof Type]: Type[Property] extends string
     ? string
-    : Type[Property] extends number
-    ? number
     : Type[Property] extends boolean
     ? number
-    : Type[Property] extends Record<string, unknown>
+    : Type[Property] extends Record<string, string>
     ? string
-    : Type[Property] extends Array<string>
-    ? Array<string>
-    : Type[Property] extends Array<number>
-    ? Array<number>
+    : Type[Property] extends Record<string, string> | undefined
+    ? string | undefined
     : Type[Property] extends Array<ObjectHandle>
     ? Array<number>
-    : Type[Property] extends Array<Record<string, unknown>>
-    ? Array<string>
-    : Type[Property] extends Array<unknown>
-    ? string
-    : Type[Property] extends Array<unknown> | undefined
-    ? string
-    : Type[Property] extends Record<string, unknown> | undefined
-    ? string | undefined
     : Type[Property] extends Date
     ? number
     : Type[Property] extends Date | undefined
     ? number | undefined
-    : Type[Property] extends string | undefined
-    ? undefined | string
-    : Type[Property] extends number | undefined
-    ? undefined | number
-    : Type[Property] extends Callback
-    ? Callback
-    : Type[Property] extends CallbackWithResponse
-    ? CallbackWithResponse
-    : Type[Property] extends Uint8Array
-    ? ArrayBuffer
     : Type[Property] extends ObjectHandle
     ? number
     : Type[Property] extends ObjectHandle | undefined
-    ? number
-    : Type[Property] extends Uint8Array | undefined
-    ? ArrayBuffer
-    : unknown
+    ? number | undefined
+    : Type[Property]
 }
 
 const serialize = (arg: Argument): SerializedArgument => {
@@ -81,14 +47,9 @@ const serialize = (arg: Argument): SerializedArgument => {
         return arg.handle
       } else if (Array.isArray(arg) && arg[0] instanceof ObjectHandle) {
         return (arg as Array<ObjectHandle>).map((a) => a.handle)
-      } else if (arg instanceof Uint8Array) {
-        return arg.buffer
       } else {
-        return JSON.stringify(arg)
+        return arg
       }
-    default:
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      throw new Error(`Could not serialize value ${arg}`)
   }
 }
 

--- a/wrappers/javascript/shared/package.json
+++ b/wrappers/javascript/shared/package.json
@@ -15,7 +15,10 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": ["build","README.md", "../../../LICENSE"],
+  "files": [
+    "build",
+    "README.md"
+  ],
   "scripts": {
     "build": "yarn run clean && yarn run compile",
     "clean": "rimraf -rf ./build",

--- a/wrappers/javascript/shared/src/IndyCredx.ts
+++ b/wrappers/javascript/shared/src/IndyCredx.ts
@@ -52,7 +52,7 @@ export interface IndyCredx {
     tag: string
     signatureType: string
     supportRevocation: boolean
-  }): [ObjectHandle, ObjectHandle, ObjectHandle]
+  }): { credentialDefinition: ObjectHandle; credentialDefinitionPrivate: ObjectHandle; keyProof: ObjectHandle }
 
   createCredential(options: {
     credentialDefinition: ObjectHandle
@@ -62,7 +62,7 @@ export interface IndyCredx {
     attributeRawValues: Record<string, string>
     attributeEncodedValues?: Record<string, string>
     revocationConfiguration?: NativeCredentialRevocationConfig
-  }): [ObjectHandle, ObjectHandle, ObjectHandle]
+  }): { credential: ObjectHandle; revocationRegistry: ObjectHandle; revocationDelta: ObjectHandle }
 
   encodeCredentialAttributes(attributeRawValues: Record<string, string>): Record<string, string>
 
@@ -79,7 +79,7 @@ export interface IndyCredx {
     revocationRegistry: ObjectHandle
     credentialRevocationIndex: number
     tailsPath: string
-  }): [ObjectHandle, ObjectHandle]
+  }): { revocationRegistry: ObjectHandle; revocationRegistryDelta: ObjectHandle }
 
   createCredentialOffer(options: {
     schemaId: string
@@ -93,7 +93,7 @@ export interface IndyCredx {
     masterSecret: ObjectHandle
     masterSecretId: string
     credentialOffer: ObjectHandle
-  }): [ObjectHandle, ObjectHandle]
+  }): { credentialRequest: ObjectHandle; credentialRequestMeta: ObjectHandle }
 
   createMasterSecret(): ObjectHandle
 
@@ -124,7 +124,12 @@ export interface IndyCredx {
     issuanceType?: string
     maximumCredentialNumber: number
     tailsDirectoryPath?: string
-  }): [ObjectHandle, ObjectHandle, ObjectHandle, ObjectHandle]
+  }): {
+    registryDefinition: ObjectHandle
+    registryDefinitionPrivate: ObjectHandle
+    registryEntry: ObjectHandle
+    registryInitDelta: ObjectHandle
+  }
 
   updateRevocationRegistry(options: {
     revocationRegistryDefinition: ObjectHandle
@@ -132,7 +137,7 @@ export interface IndyCredx {
     issued: number[]
     revoked: number[]
     tailsDirectoryPath: string
-  }): [ObjectHandle, ObjectHandle]
+  }): { revocationRegistry: ObjectHandle; revocationRegistryDelta: ObjectHandle }
 
   mergeRevocationRegistryDeltas(options: {
     revocationRegistryDelta1: ObjectHandle

--- a/wrappers/javascript/shared/src/IndyCredx.ts
+++ b/wrappers/javascript/shared/src/IndyCredx.ts
@@ -5,8 +5,8 @@ import type { ObjectHandle } from './ObjectHandle'
 
 export type NativeCredentialEntry = {
   credential: ObjectHandle
-  timestamp: number
-  revocationState: ObjectHandle
+  timestamp?: number
+  revocationState?: ObjectHandle
 }
 
 export type NativeCredentialProve = {
@@ -112,8 +112,8 @@ export interface IndyCredx {
     presentationRequest: ObjectHandle
     schemas: ObjectHandle[]
     credentialDefinitions: ObjectHandle[]
-    revocationRegistryDefinitions: ObjectHandle[]
-    revocationEntries: NativeRevocationEntry[]
+    revocationRegistryDefinitions?: ObjectHandle[]
+    revocationEntries?: NativeRevocationEntry[]
   }): boolean
 
   createRevocationRegistry(options: {

--- a/wrappers/javascript/shared/src/api/Credential.ts
+++ b/wrappers/javascript/shared/src/api/Credential.ts
@@ -32,7 +32,7 @@ export type ProcessCredentialOptions = {
 
 export class Credential extends IndyObject {
   public static create(options: CreateCredentialOptions) {
-    const [cred, revReg, revDelta] = indyCredx.createCredential({
+    const { credential, revocationDelta, revocationRegistry } = indyCredx.createCredential({
       credentialDefinition: options.credentialDefinition.handle,
       credentialDefinitionPrivate: options.credentialDefinitionPrivate.handle,
       credentialRequest: options.credentialRequest.handle,
@@ -43,9 +43,9 @@ export class Credential extends IndyObject {
     })
 
     return {
-      credential: new Credential(cred.handle),
-      revocationRegistry: revReg ? new RevocationRegistry(revReg.handle) : undefined,
-      revocationRegistryDelta: revDelta ? new RevocationRegistryDelta(revDelta.handle) : undefined,
+      credential: new Credential(credential.handle),
+      revocationRegistry: revocationRegistry ? new RevocationRegistry(revocationRegistry.handle) : undefined,
+      revocationRegistryDelta: revocationDelta ? new RevocationRegistryDelta(revocationDelta.handle) : undefined,
     }
   }
 

--- a/wrappers/javascript/shared/src/api/CredentialDefinition.ts
+++ b/wrappers/javascript/shared/src/api/CredentialDefinition.ts
@@ -16,7 +16,7 @@ export type CreateCredentialDefinitionOptions = {
 
 export class CredentialDefinition extends IndyObject {
   public static create(options: CreateCredentialDefinitionOptions) {
-    const [credDef, credDefPvt, keyProof] = indyCredx.createCredentialDefinition({
+    const { credentialDefinition, credentialDefinitionPrivate, keyProof } = indyCredx.createCredentialDefinition({
       originDid: options.originDid,
       schema: options.schema.handle,
       signatureType: options.signatureType,
@@ -25,8 +25,8 @@ export class CredentialDefinition extends IndyObject {
     })
 
     return {
-      credentialDefinition: new CredentialDefinition(credDef.handle),
-      credentialDefinitionPrivate: new CredentialDefinitionPrivate(credDefPvt.handle),
+      credentialDefinition: new CredentialDefinition(credentialDefinition.handle),
+      credentialDefinitionPrivate: new CredentialDefinitionPrivate(credentialDefinitionPrivate.handle),
       keyCorrectnessProof: new KeyCorrectnessProof(keyProof.handle),
     }
   }

--- a/wrappers/javascript/shared/src/api/CredentialRequest.ts
+++ b/wrappers/javascript/shared/src/api/CredentialRequest.ts
@@ -17,7 +17,7 @@ export type CreateCredentialRequestOptions = {
 
 export class CredentialRequest extends IndyObject {
   public static create(options: CreateCredentialRequestOptions) {
-    const [credReq, credReqMetadata] = indyCredx.createCredentialRequest({
+    const { credentialRequest, credentialRequestMeta } = indyCredx.createCredentialRequest({
       proverDid: options.proverDid,
       credentialDefinition: options.credentialDefinition.handle,
       masterSecret: options.masterSecret.handle,
@@ -26,8 +26,8 @@ export class CredentialRequest extends IndyObject {
     })
 
     return {
-      credentialRequest: new CredentialRequest(credReq.handle),
-      credentialRequestMetadata: new CredentialRequestMetadata(credReqMetadata.handle),
+      credentialRequest: new CredentialRequest(credentialRequest.handle),
+      credentialRequestMetadata: new CredentialRequestMetadata(credentialRequestMeta.handle),
     }
   }
 

--- a/wrappers/javascript/shared/src/api/RevocationRegistry.ts
+++ b/wrappers/javascript/shared/src/api/RevocationRegistry.ts
@@ -24,20 +24,20 @@ export class RevocationRegistry extends IndyObject {
   }
 
   public revokeCredential(options: RevokeCredentialOptions) {
-    const [handle, revDelta] = indyCredx.revokeCredential({
+    const { revocationRegistry, revocationRegistryDelta } = indyCredx.revokeCredential({
       revocationRegistryDefinition: options.revocationRegistryDefinition.handle,
       revocationRegistry: this._handle,
       credentialRevocationIndex: options.credentialRevocationIndex,
       tailsPath: options.tailsPath,
     })
 
-    this._handle = handle
+    this._handle = revocationRegistry
 
-    return new RevocationRegistryDelta(revDelta.handle)
+    return new RevocationRegistryDelta(revocationRegistryDelta.handle)
   }
 
   public update(options: UpdateRevocationRegistryOptions) {
-    const [handle, revDelta] = indyCredx.updateRevocationRegistry({
+    const { revocationRegistry, revocationRegistryDelta } = indyCredx.updateRevocationRegistry({
       revocationRegistryDefinition: options.revocationRegistryDefinition.handle,
       revocationRegistry: this._handle,
       issued: options.issued,
@@ -45,8 +45,8 @@ export class RevocationRegistry extends IndyObject {
       tailsDirectoryPath: options.tailsDirectoryPath,
     })
 
-    this._handle = handle
+    this._handle = revocationRegistry
 
-    return new RevocationRegistryDelta(revDelta.handle)
+    return new RevocationRegistryDelta(revocationRegistryDelta.handle)
   }
 }

--- a/wrappers/javascript/shared/src/api/RevocationRegistryDefinition.ts
+++ b/wrappers/javascript/shared/src/api/RevocationRegistryDefinition.ts
@@ -19,21 +19,22 @@ export type CreateRevocationRegistryDefinitionOptions = {
 
 export class RevocationRegistryDefinition extends IndyObject {
   public static create(options: CreateRevocationRegistryDefinitionOptions) {
-    const [regDef, regDefPrivate, regEntry, regInitDelta] = indyCredx.createRevocationRegistry({
-      originDid: options.originDid,
-      credentialDefinition: options.credentialDefinition.handle,
-      tag: options.tag,
-      revocationRegistryType: options.revocationRegistryType,
-      issuanceType: options.issuanceType,
-      maximumCredentialNumber: options.maximumCredentialNumber,
-      tailsDirectoryPath: options.tailsDirectoryPath,
-    })
+    const { registryDefinition, registryDefinitionPrivate, registryEntry, registryInitDelta } =
+      indyCredx.createRevocationRegistry({
+        originDid: options.originDid,
+        credentialDefinition: options.credentialDefinition.handle,
+        tag: options.tag,
+        revocationRegistryType: options.revocationRegistryType,
+        issuanceType: options.issuanceType,
+        maximumCredentialNumber: options.maximumCredentialNumber,
+        tailsDirectoryPath: options.tailsDirectoryPath,
+      })
 
     return {
-      revocationRegistryDefinition: new RevocationRegistryDefinition(regDef.handle),
-      revocationRegistryDefinitionPrivate: new RevocationRegistryDefinitionPrivate(regDefPrivate.handle),
-      revocationRegistry: new RevocationRegistry(regEntry.handle),
-      revocationRegistryDelta: new RevocationRegistryDelta(regInitDelta.handle),
+      revocationRegistryDefinition: new RevocationRegistryDefinition(registryDefinition.handle),
+      revocationRegistryDefinitionPrivate: new RevocationRegistryDefinitionPrivate(registryDefinitionPrivate.handle),
+      revocationRegistry: new RevocationRegistry(registryEntry.handle),
+      revocationRegistryDelta: new RevocationRegistryDelta(registryInitDelta.handle),
     }
   }
 

--- a/wrappers/javascript/shared/tsconfig.build.json
+++ b/wrappers/javascript/shared/tsconfig.build.json
@@ -1,9 +1,7 @@
 {
   "extends": "../tsconfig.build.json",
-
   "compilerOptions": {
     "outDir": "./build"
   },
-
   "include": ["src/**/*"]
 }

--- a/wrappers/javascript/shared/tsconfig.json
+++ b/wrappers/javascript/shared/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../tsconfig.json"
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest"]
+  }
 }

--- a/wrappers/javascript/tsconfig.build.json
+++ b/wrappers/javascript/tsconfig.build.json
@@ -9,14 +9,8 @@
     "lib": ["ESNext"],
     "types": [],
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "baseUrl": ".",
-    "paths": {
-      "indy-credx-shared": ["shared/src"],
-      "indy-credx-react-native": ["react-native/src"],
-      "indy-credx-nodejs": ["nodejs/src"]
-    }
+    "baseUrl": "."
   },
   "exclude": ["node_modules", "build", "**/build/**"]
 }

--- a/wrappers/javascript/yarn.lock
+++ b/wrappers/javascript/yarn.lock
@@ -18,9 +18,9 @@
     "@babel/highlight" "^7.18.6"
 
 "@babel/compat-data@^7.17.7", "@babel/compat-data@^7.18.8":
-  version "7.18.8"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.8.tgz#2483f565faca607b8535590e84e7de323f27764d"
-  integrity sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.13.tgz#6aff7b350a1e8c3e40b029e46cbe78e24a913483"
+  integrity sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==
 
 "@babel/core@7.17.9":
   version "7.17.9"
@@ -44,32 +44,32 @@
     semver "^6.3.0"
 
 "@babel/core@^7.1.6", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.14.0":
-  version "7.18.10"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.10.tgz#39ad504991d77f1f3da91be0b8b949a5bc466fb8"
-  integrity sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.13.tgz#9be8c44512751b05094a4d3ab05fc53a47ce00ac"
+  integrity sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==
   dependencies:
     "@ampproject/remapping" "^2.1.0"
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.18.10"
+    "@babel/generator" "^7.18.13"
     "@babel/helper-compilation-targets" "^7.18.9"
     "@babel/helper-module-transforms" "^7.18.9"
     "@babel/helpers" "^7.18.9"
-    "@babel/parser" "^7.18.10"
+    "@babel/parser" "^7.18.13"
     "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.18.10"
-    "@babel/types" "^7.18.10"
+    "@babel/traverse" "^7.18.13"
+    "@babel/types" "^7.18.13"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/generator@^7.14.0", "@babel/generator@^7.17.9", "@babel/generator@^7.18.10", "@babel/generator@^7.7.2":
-  version "7.18.12"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.12.tgz#fa58daa303757bd6f5e4bbca91b342040463d9f4"
-  integrity sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==
+"@babel/generator@^7.14.0", "@babel/generator@^7.17.9", "@babel/generator@^7.18.13", "@babel/generator@^7.7.2":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.13.tgz#59550cbb9ae79b8def15587bdfbaa388c4abf212"
+  integrity sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==
   dependencies:
-    "@babel/types" "^7.18.10"
+    "@babel/types" "^7.18.13"
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
@@ -99,9 +99,9 @@
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz#d802ee16a64a9e824fcbf0a2ffc92f19d58550ce"
-  integrity sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.13.tgz#63e771187bd06d234f95fdf8bd5f8b6429de6298"
+  integrity sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.18.6"
     "@babel/helper-environment-visitor" "^7.18.9"
@@ -283,10 +283,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.14.0", "@babel/parser@^7.14.7", "@babel/parser@^7.17.9", "@babel/parser@^7.18.10", "@babel/parser@^7.18.11":
-  version "7.18.11"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.11.tgz#68bb07ab3d380affa9a3f96728df07969645d2d9"
-  integrity sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==
+"@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.14.0", "@babel/parser@^7.14.7", "@babel/parser@^7.17.9", "@babel/parser@^7.18.10", "@babel/parser@^7.18.13":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.13.tgz#5b2dd21cae4a2c5145f1fbd8ca103f9313d3b7e4"
+  integrity sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==
 
 "@babel/plugin-proposal-class-properties@^7.0.0", "@babel/plugin-proposal-class-properties@^7.1.0":
   version "7.18.6"
@@ -511,9 +511,9 @@
     "@babel/helper-plugin-utils" "^7.18.9"
 
 "@babel/plugin-transform-destructuring@^7.0.0":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.9.tgz#68906549c021cb231bee1db21d3b5b095f8ee292"
-  integrity sha512-p5VCYNddPLkZTq4XymQIaIfZNJwT9YsjkPOhkVEqt6QIpQFZVM9IltqqYpOEkJoN1DPznmxUDyZ5CTZs/ZCuHA==
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.13.tgz#9e03bc4a94475d62b7f4114938e6c5c33372cbf5"
+  integrity sha512-TodpQ29XekIsex2A+YJPj5ax2plkGa8YYY6mFjCohk/IG9IY42Rtuj1FuDeemfg2ipxIFLzPeA83SIBnlhSIow==
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.9"
 
@@ -752,26 +752,26 @@
     "@babel/parser" "^7.18.10"
     "@babel/types" "^7.18.10"
 
-"@babel/traverse@^7.14.0", "@babel/traverse@^7.17.9", "@babel/traverse@^7.18.10", "@babel/traverse@^7.18.11", "@babel/traverse@^7.18.9", "@babel/traverse@^7.7.2":
-  version "7.18.11"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.11.tgz#3d51f2afbd83ecf9912bcbb5c4d94e3d2ddaa16f"
-  integrity sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==
+"@babel/traverse@^7.14.0", "@babel/traverse@^7.17.9", "@babel/traverse@^7.18.11", "@babel/traverse@^7.18.13", "@babel/traverse@^7.18.9", "@babel/traverse@^7.7.2":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.13.tgz#5ab59ef51a997b3f10c4587d648b9696b6cb1a68"
+  integrity sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==
   dependencies:
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.18.10"
+    "@babel/generator" "^7.18.13"
     "@babel/helper-environment-visitor" "^7.18.9"
     "@babel/helper-function-name" "^7.18.9"
     "@babel/helper-hoist-variables" "^7.18.6"
     "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.18.11"
-    "@babel/types" "^7.18.10"
+    "@babel/parser" "^7.18.13"
+    "@babel/types" "^7.18.13"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.17.0", "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
-  version "7.18.10"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.10.tgz#4908e81b6b339ca7c6b7a555a5fc29446f26dde6"
-  integrity sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==
+"@babel/types@^7.0.0", "@babel/types@^7.17.0", "@babel/types@^7.18.10", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.13.tgz#30aeb9e514f4100f7c1cb6e5ba472b30e48f519a"
+  integrity sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==
   dependencies:
     "@babel/helper-string-parser" "^7.18.10"
     "@babel/helper-validator-identifier" "^7.18.6"
@@ -797,7 +797,7 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@eslint/eslintrc@^1.0.5":
+"@eslint/eslintrc@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.0.tgz#29f92c30bb3e771e4a2048c95fa6855392dfac4f"
   integrity sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==
@@ -824,14 +824,19 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@humanwhocodes/config-array@^0.9.2":
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"
-  integrity sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==
+"@humanwhocodes/config-array@^0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.4.tgz#01e7366e57d2ad104feea63e72248f22015c520c"
+  integrity sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
     minimatch "^3.0.4"
+
+"@humanwhocodes/gitignore-to-minimatch@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz#316b0a63b91c10e53f242efb4ace5c3b34e8728d"
+  integrity sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==
 
 "@humanwhocodes/object-schema@^1.2.1":
   version "1.2.1"
@@ -1042,6 +1047,18 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.1"
 
+"@jest/types@28.1.3", "@jest/types@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-28.1.3.tgz#b05de80996ff12512bc5ceb1d208285a7d11748b"
+  integrity sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==
+  dependencies:
+    "@jest/schemas" "^28.1.3"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
 "@jest/types@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
@@ -1062,18 +1079,6 @@
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
     "@types/yargs" "^16.0.0"
-    chalk "^4.0.0"
-
-"@jest/types@^28.1.3":
-  version "28.1.3"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-28.1.3.tgz#b05de80996ff12512bc5ceb1d208285a7d11748b"
-  integrity sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==
-  dependencies:
-    "@jest/schemas" "^28.1.3"
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
 "@jridgewell/gen-mapping@^0.1.0":
@@ -1117,9 +1122,9 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.13", "@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.14"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz#b231a081d8f66796e475ad588a1ef473112701ed"
-  integrity sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz#aba35c48a38d3fd84b37e66c9c0423f9744f9774"
+  integrity sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
@@ -1144,6 +1149,18 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@pkgr/utils@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.3.0.tgz#3b8491f112a80839450498816767eb03b7db6139"
+  integrity sha512-7dIJ9CRVzBnqyEl7diUHPUFJf/oty2SeoVzcMocc5PeOUDK9KGzvgIBjGRRzzlRDaOjh3ADwH0WeibQvi3ls2Q==
+  dependencies:
+    cross-spawn "^7.0.3"
+    is-glob "^4.0.3"
+    open "^8.4.0"
+    picocolors "^1.0.0"
+    tiny-glob "^0.2.9"
+    tslib "^2.4.0"
 
 "@react-native-community/cli-debugger-ui@^6.0.0-rc.0":
   version "6.0.0"
@@ -1315,9 +1332,9 @@
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sinclair/typebox@^0.24.1":
-  version "0.24.27"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.27.tgz#d55643516a1546174e10da681a8aaa81e757452d"
-  integrity sha512-K7C7IlQ3zLePEZleUN21ceBA2aLcMnLHTLph8QWk1JK37L90obdpY+QGY8bXMKxf1ht1Z0MNewvXxWv0oGDYFg==
+  version "0.24.28"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.28.tgz#15aa0b416f82c268b1573ab653e4413c965fe794"
+  integrity sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -1453,9 +1470,9 @@
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
 "@types/node@*":
-  version "18.7.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.1.tgz#352bee64f93117d867d05f7406642a52685cbca6"
-  integrity sha512-GKX1Qnqxo4S+Z/+Z8KKPLpH282LD7jLHWJcVryOflnsnH+BtSDfieR6ObwBMwpnNws0bUK8GI7z0unQf9bARNQ==
+  version "18.7.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.11.tgz#486e72cfccde88da24e1f23ff1b7d8bfb64e6250"
+  integrity sha512-KZhFpSLlmK/sdocfSAjqPETTMd0ug6HIMIAwkwUpU79olnZdQtMxpQP+G1wDzCH7na+FltSIhbaZuKdwZ8RDrw==
 
 "@types/node@17.0.31":
   version "17.0.31"
@@ -2158,9 +2175,9 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001370:
-  version "1.0.30001375"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001375.tgz#8e73bc3d1a4c800beb39f3163bf0190d7e5d7672"
-  integrity sha512-kWIMkNzLYxSvnjy0hL8w1NOaWNr2rn39RTAVyIwcw8juu60bZDWiF1/loOYANzjtJmy6qPgNmn38ro5Pygagdw==
+  version "1.0.30001382"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001382.tgz#4d37f0d0b6fffb826c8e5e1c0f4bf8ce592db949"
+  integrity sha512-2rtJwDmSZ716Pxm1wCtbPvHtbDWAreTPxXbkc5RkKglow3Ig/4GNGazDI9/BVnXbG/wnv6r3B5FEbkfg9OcTGg==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -2456,9 +2473,9 @@ d@1, d@^1.0.1:
     type "^1.0.1"
 
 dayjs@^1.8.15:
-  version "1.11.4"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.4.tgz#3b3c10ca378140d8917e06ebc13a4922af4f433e"
-  integrity sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g==
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.5.tgz#00e8cc627f231f9499c19b38af49f56dc0ac5e93"
+  integrity sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
@@ -2474,7 +2491,7 @@ debug@^3.1.0, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
+debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -2517,6 +2534,11 @@ defaults@^1.0.3:
   integrity sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==
   dependencies:
     clone "^1.0.2"
+
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
 
 define-properties@^1.1.3, define-properties@^1.1.4:
   version "1.1.4"
@@ -2605,9 +2627,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.202:
-  version "1.4.215"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.215.tgz#553372e74bde3164290d61f6792f93e443b16733"
-  integrity sha512-vqZxT8C5mlDZ//hQFhneHmOLnj1LhbzxV0+I1yqHV8SB1Oo4Y5Ne9+qQhwHl7O1s9s9cRuo2l5CoLEHdhMTwZg==
+  version "1.4.227"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.227.tgz#28e46e2a701fed3188db3ca7bf0a3a475e484046"
+  integrity sha512-I9VVajA3oswIJOUFg2PSBqrHLF5Y+ahIfjOV9+v6uYyBqFZutmPxA6fxocDUUmgwYevRWFu1VjLyVG3w45qa/g==
 
 emittery@^0.10.2:
   version "0.10.2"
@@ -2630,6 +2652,14 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+enhanced-resolve@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
+  integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
 
 envinfo@^7.7.2:
   version "7.8.1"
@@ -2767,24 +2797,25 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
-eslint-import-resolver-typescript@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.5.0.tgz#07661966b272d14ba97f597b51e1a588f9722f0a"
-  integrity sha512-qZ6e5CFr+I7K4VVhQu3M/9xGv9/YmwsEXrsm3nimw8vWaVHRDrQRp26BgCypTxBp3vUp4o5aVEJRiy0F2DFddQ==
+eslint-import-resolver-typescript@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.0.tgz#490ba48cafc5a2fb209bbc7e360defb4c292ed59"
+  integrity sha512-DEfpfuk+O/T5e9HBZOxocmwMuUGkvQQd5WRiMJF9kKNT9amByqOyGlWoAZAQiv0SZSy4GMtG1clmnvQA/RzA0A==
   dependencies:
-    debug "^4.3.1"
-    glob "^7.1.7"
-    is-glob "^4.0.1"
-    resolve "^1.20.0"
-    tsconfig-paths "^3.9.0"
+    debug "^4.3.4"
+    enhanced-resolve "^5.10.0"
+    get-tsconfig "^4.2.0"
+    globby "^13.1.2"
+    is-core-module "^2.10.0"
+    is-glob "^4.0.3"
+    synckit "^0.8.3"
 
 eslint-module-utils@^2.7.2:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz#ad7e3a10552fdd0642e1e55292781bd6e34876ee"
-  integrity sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974"
+  integrity sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==
   dependencies:
     debug "^3.2.7"
-    find-up "^2.1.0"
 
 eslint-plugin-import@2.25.4:
   version "2.25.4"
@@ -2820,7 +2851,7 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.1.0:
+eslint-scope@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
   integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
@@ -2840,35 +2871,39 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.2.0, eslint-visitor-keys@^3.3.0:
+eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-eslint@8.8.0:
-  version "8.8.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.8.0.tgz#9762b49abad0cb4952539ffdb0a046392e571a2d"
-  integrity sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==
+eslint@8.22.0:
+  version "8.22.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.22.0.tgz#78fcb044196dfa7eef30a9d65944f6f980402c48"
+  integrity sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==
   dependencies:
-    "@eslint/eslintrc" "^1.0.5"
-    "@humanwhocodes/config-array" "^0.9.2"
+    "@eslint/eslintrc" "^1.3.0"
+    "@humanwhocodes/config-array" "^0.10.4"
+    "@humanwhocodes/gitignore-to-minimatch" "^1.0.2"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
     debug "^4.3.2"
     doctrine "^3.0.0"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^7.1.0"
+    eslint-scope "^7.1.1"
     eslint-utils "^3.0.0"
-    eslint-visitor-keys "^3.2.0"
-    espree "^9.3.0"
+    eslint-visitor-keys "^3.3.0"
+    espree "^9.3.3"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
     file-entry-cache "^6.0.1"
+    find-up "^5.0.0"
     functional-red-black-tree "^1.0.1"
     glob-parent "^6.0.1"
-    globals "^13.6.0"
+    globals "^13.15.0"
+    globby "^11.1.0"
+    grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
@@ -2877,7 +2912,7 @@ eslint@8.8.0:
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
     lodash.merge "^4.6.2"
-    minimatch "^3.0.4"
+    minimatch "^3.1.2"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
     regexpp "^3.2.0"
@@ -2886,7 +2921,7 @@ eslint@8.8.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^9.3.0, espree@^9.3.2:
+espree@^9.3.2, espree@^9.3.3:
   version "9.3.3"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.3.tgz#2dd37c4162bb05f433ad3c1a52ddf8a49dc08e9d"
   integrity sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==
@@ -3047,7 +3082,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@^3.2.9:
+fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -3140,13 +3175,6 @@ find-cache-dir@^2.0.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
-find-up@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
-  integrity sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==
-  dependencies:
-    locate-path "^2.0.0"
-
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -3162,6 +3190,14 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -3171,14 +3207,14 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.1.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.6.tgz#022e9218c637f9f3fc9c35ab9c9193f05add60b2"
-  integrity sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
+  integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 flow-parser@0.*:
-  version "0.184.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.184.0.tgz#45faed0a40fa554d24550c35ec7889b86b360c9b"
-  integrity sha512-+RAHizWmCnfnAWX1yD3fSdWRYCMhGiiqZSbHNU38MQxYc8XdTBoFB3ZpL1MEPG6yy/Yb3hg9w9eIf0DNlU8epQ==
+  version "0.185.1"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.185.1.tgz#32777ecbb7c6fa272713077599e6fb44fb2331c3"
+  integrity sha512-nbtJZFMGgJVCRBlE/66p7L6IWF+wy6Nbd65sVwyrH7WsnZgeef8m263uxN4xah+8BZwuGndU8HKlt8cHIpTwew==
 
 flow-parser@^0.121.0:
   version "0.121.0"
@@ -3304,6 +3340,11 @@ get-symbol-from-current-process-h@^1.0.1, get-symbol-from-current-process-h@^1.0
   resolved "https://registry.yarnpkg.com/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz#510af52eaef873f7028854c3377f47f7bb200265"
   integrity sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw==
 
+get-tsconfig@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.2.0.tgz#ff368dd7104dab47bf923404eb93838245c66543"
+  integrity sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==
+
 get-uv-event-loop-napi-h@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz#42b0b06b74c3ed21fbac8e7c72845fdb7a200208"
@@ -3330,7 +3371,7 @@ glob-parent@^6.0.1:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^7.1.3, glob@^7.1.4, glob@^7.1.7:
+glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -3347,14 +3388,19 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globals@^13.15.0, globals@^13.6.0:
+globals@^13.15.0:
   version "13.17.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.17.0.tgz#902eb1e680a41da93945adbdcb5a9f361ba69bd4"
   integrity sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.4:
+globalyzer@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/globalyzer/-/globalyzer-0.1.0.tgz#cb76da79555669a1519d5a8edf093afaa0bf1465"
+  integrity sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==
+
+globby@^11.0.4, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -3366,10 +3412,31 @@ globby@^11.0.4:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+globby@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.2.tgz#29047105582427ab6eca4f905200667b056da515"
+  integrity sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==
+  dependencies:
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.11"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
+
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
@@ -3605,7 +3672,7 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.8.0, is-core-module@^2.9.0:
+is-core-module@^2.10.0, is-core-module@^2.8.0, is-core-module@^2.9.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
   integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
@@ -3655,6 +3722,11 @@ is-directory@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==
+
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -3781,6 +3853,13 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -4452,14 +4531,6 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-locate-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
-  integrity sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==
-  dependencies:
-    p-locate "^2.0.0"
-    path-exists "^3.0.0"
-
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -4474,6 +4545,13 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -5107,9 +5185,9 @@ object-visit@^1.0.0:
     isobject "^3.0.0"
 
 object.assign@^4.1.0, object.assign@^4.1.2:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.3.tgz#d36b7700ddf0019abb6b1df1bb13f6445f79051f"
-  integrity sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
+  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
@@ -5179,6 +5257,15 @@ open@^6.2.0:
   dependencies:
     is-wsl "^1.1.0"
 
+open@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
+  integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
+
 optionator@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
@@ -5218,13 +5305,6 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
 
-p-limit@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
-  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
-  dependencies:
-    p-try "^1.0.0"
-
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -5232,19 +5312,12 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.1.0:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
-
-p-locate@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
-  integrity sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==
-  dependencies:
-    p-limit "^1.1.0"
 
 p-locate@^3.0.0:
   version "3.0.0"
@@ -5260,10 +5333,12 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
-p-try@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-  integrity sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -5992,6 +6067,11 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
+  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
+
 slice-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
@@ -6252,6 +6332,19 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+synckit@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.3.tgz#f36ca23fb7cbcf2b2b78c9e553ce6764dc6aa415"
+  integrity sha512-1goXnDYNJlKwCM37f5MTzRwo+8SqutgVtg2d37D6YnHHT4E3IhQMRfKiGdfTZU7LBlI6T8inCQUxnMBFHrbqWw==
+  dependencies:
+    "@pkgr/utils" "^2.3.0"
+    tslib "^2.4.0"
+
+tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
+
 temp@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
@@ -6301,6 +6394,14 @@ through2@^2.0.1:
   dependencies:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
+
+tiny-glob@^0.2.9:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/tiny-glob/-/tiny-glob-0.2.9.tgz#2212d441ac17928033b110f8b3640683129d31e2"
+  integrity sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==
+  dependencies:
+    globalyzer "0.1.0"
+    globrex "^0.1.2"
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -6396,7 +6497,7 @@ tsconfig-paths@4.1.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tsconfig-paths@^3.12.0, tsconfig-paths@^3.9.0:
+tsconfig-paths@^3.12.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
   integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==
@@ -6411,7 +6512,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.1:
+tslib@^2.0.1, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
@@ -6720,9 +6821,9 @@ write-file-atomic@^2.3.0:
     signal-exit "^3.0.2"
 
 write-file-atomic@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-4.0.1.tgz#9faa33a964c1c85ff6f849b80b42a88c2c537c8f"
-  integrity sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-4.0.2.tgz#a9df01ae5b77858a027fd2e80768ee433555fcfd"
+  integrity sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"


### PR DESCRIPTION
- Reworks the monorepo so eslint and everything is well typed again
- Also adds some CPP + Rn code as I forgot to commit that before.

BREAKING:

changed the return type of the lists of object handles to just "named" objects.

Signed-off-by: blu3beri <berend@animo.id>